### PR TITLE
Update getconsensusnetwork.py to support single-directory adjmat directories

### DIFF
--- a/getconsensusnetwork.py
+++ b/getconsensusnetwork.py
@@ -24,10 +24,15 @@ run_num = 0
 mu = 0
 sigma = 0
 
+# Command-line arguments
+adjmat_dir   = sys.argv[1]
+p_thresh_arg = sys.argv[2]
+output_dir   = sys.argv[3]
+
 # Processing all bootstrap networks, summarizing them into corresponding variables
-for adj_file in os.listdir(sys.argv[1]):
+for adj_file in os.listdir(adjmat_dir):
 	total_edge.append(0)
-	with open(sys.argv[1] + adj_file, 'r') as f:	# Opening each bootstrap file
+	with open(adjmat_dir + adj_file, 'r') as f:	# Opening each bootstrap file
 		for line in f:
 			if line[0] == '>' and run_num == 0:
 				parameters += line
@@ -46,23 +51,29 @@ for adj_file in os.listdir(sys.argv[1]):
 	run_num += 1	# Increment the bootstrap file index
 
 # Network name
-path_tokens = sys.argv[1].split('/')
-name = path_tokens[len(path_tokens) - 2]
-path = '/'.join(path_tokens[0:len(path_tokens) - 2]) + '/'
+name = os.path.basename(os.path.dirname(adjmat_dir))
 
 # Archiving the bootstrap networks
 current_path = os.getcwd()
-os.chdir(path)
+
+# Parent directory of adjacency matrix output
+path = os.path.dirname(os.path.dirname(adjmat_dir))
+
+# If we aren't already in the parent directory of the adjacency matrix output dir, change to it
+if path is not '':
+    os.chdir(path)
 with closing(tarfile.open(name + '.tar.gz', "w:gz")) as tar:
 	for f in os.listdir(name):
-	    tar.add(name + '/' + f)
+	    tar.add(os.path.join(name, f))
+
+# Return to the original directory from which the script was called
 os.chdir(current_path)
-shutil.rmtree(sys.argv[1])
+shutil.rmtree(adjmat_dir)
 
 # Writing out the summary of all bootstrap files into bootstrap_info.txt file
-info_file = open(sys.argv[3] + 'bootstrap_info_.txt' if sys.argv[3].endswith('/') else sys.argv[3] + '/bootstrap_info_.txt', 'w')
+info_file = open(os.path.join(output_dir, 'bootstrap_info_.txt'), 'w')
 info_file.write('Total edge tested: ' + str(len(total_support)) + '\n')
-info_file.write('Bonferroni corrected (0.05) alpha: ' + str(0.05/len(total_support)) + '\n')
+info_file.write('Bonferroni corrected (0.05) alpha: ' + str(0.05 / len(total_support)) + '\n')
 
 # Computing mu and sigma accross all bootstrap files
 for i in range(0, run_num):
@@ -76,18 +87,20 @@ info_file.write('sigma: ' + str(sigma) + '\n')
 
 # Setting p_threshold if given to the given value, if not to Bonferroni corrected value
 p_threshold = 0.05 / len(total_support)
-if sys.argv[2] != None:
-	p_threshold = float(sys.argv[2])
+
+if p_thresh_arg != None:
+	p_threshold = float(p_thresh_arg)
 
 # Writing out the parameters that the bootstrap networks are constructed with plus other parameters that is used to create consensus network
-parameter_file = open(sys.argv[3] + 'parameter_info_.txt' if sys.argv[3].endswith('/') else sys.argv[3] + '/parameter_info_.txt', 'w')
+parameter_file = open(os.path.join(output_dir, 'parameter_info_.txt'), 'w')
 parameters += '>  Bootstrap No: ' + str(run_num) + '\n'
 parameters += '>  Source: sjaracne\n'
-parameters += '>  Output network: ' + (sys.argv[3] + 'consensus_network_3col_.txt' if sys.argv[3].endswith('/') else sys.argv[3] + '/consensus_network_3col_.txt') + '\n'
+parameters += '>  Output network: ' + os.path.join(output_dir, 'consensus_network_3col_.txt') + '\n'
 parameter_file.write(parameters)
 
 # Writing out the consensus network preserving edges with statistically significant support
-consensus_network = open(sys.argv[3] + 'consensus_network_3col_.txt' if sys.argv[3].endswith('/') else sys.argv[3] + '/consensus_network_3col_.txt', 'w')
+consensus_network = open(os.path.join(output_dir, 'consensus_network_3col_.txt'), 'w')
+
 header += 'source\ttarget\tMI\n'
 consensus_network.write(header)
 current_gene = 'none'


### PR DESCRIPTION
This PR fixes an issue which causes `getconsensusnetwork.py` to fail when the filepath to the output adjacency matrices consists of only a single relative directory (e.g. `getconsensusnetwork.py outputsjaracne_foo_out_/ ...`).

Also did a little cleaning up to make use of  Python's built-in support for filepath construction (If only support Python 3, one could also make use of [pathlib](https://docs.python.org/3/library/pathlib.html)).

Incidentally, in the future, it might be useful to adopt [PEP8](https://www.python.org/dev/peps/pep-0008/) for any Python code. The suggestions there are not that onerous to apply, but generally lead to much more readable code. Adopting similar conventions in my own work tends to make future me much happier with present me :smile_cat:.