### PR TITLE
Fixed problem where name of gene could not have spaces

### DIFF
--- a/SJARACNe/bin/QC_input.py
+++ b/SJARACNe/bin/QC_input.py
@@ -31,7 +31,7 @@ def check_exp(input_file):
             if len(words) != entries_per_line:
                 logging.info("Line {} does not have an appropriate number of entries".format(total_genes+1))
                 sys.exit('Error - number of entries per line is not consistent across file. See line {}'.format(total_genes+1))
-            for word in words:
+            for word in words[2:]:
                 if ' ' in word:
                     logging.info("Word with spaces is: {}".format(word))
                     sys.exit('Error - spaces are not allowed, only tabs can delimit input file. Space found in line {}'.format(total_genes+1))


### PR DESCRIPTION
Names can have spaces if they are the name or description of gene. To circumvent this problem, I changed line 34 in QC_input.py from `for word in words:` to `for word in words[2:]:`. This way we ignore the first two elements in every line, given they're just the ID and the gene name.