### PR TITLE
Fix potential network correctness issues

### DIFF
--- a/SJARACNe/bin/QC_input.py
+++ b/SJARACNe/bin/QC_input.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 
 import argparse
-import sys
 import logging
+import re
+import sys
+
+
+DEFAULT_REPORT_FILE = 'hub_overlap_validation.txt'
+BOUNDARY_WHITESPACE = ' \t\n\r\f\v'
 
 
 def main():
@@ -10,25 +15,29 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=head_description)
     parser.add_argument('-e', '--exp-file', metavar='STR', required=True, help='exp file')
     parser.add_argument('-g', '--probe-file', metavar='STR', required=True, help='probe file')
+    parser.add_argument('-o', '--output-file', metavar='STR', default=DEFAULT_REPORT_FILE,
+                        help='output validation report')
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
 
-    check_exp(args.exp_file)
-    check_probe(args.probe_file)
+    validate_inputs(args.exp_file, args.probe_file, args.output_file)
 
 
 def check_exp(input_file):
     total_genes = 0
-    with open(input_file, 'r') as fin:
+    expression_ids = set()
+
+    with open(input_file, 'r', encoding='utf-8-sig', newline=None) as fin:
         # process header
-        header = fin.readline()
+        header = fin.readline().rstrip('\r\n')
         words = header.split('\t')
-        if words[0] != 'isoformId' or words[1] != 'geneSymbol':
+        if len(words) < 2 or words[0] != 'isoformId' or words[1] != 'geneSymbol':
             sys.exit('Error - Improper header in input file: first two column names must be isoformId and '
                      'geneSymbol respectively.')
         entries_per_line = len(words)
         # process rest of the file, making sure tabs are splitting entries
         for line in fin:
+            line = line.rstrip('\r\n')
             words = line.split('\t')
             total_genes += 1  # add one gene to the total count per line of the exp file
             if len(words) != entries_per_line:
@@ -44,19 +53,87 @@ def check_exp(input_file):
                     logging.info("Numeric entry missing spacing is: {}".format(word))
                     sys.exit('Error - There are some numeric entries missing tab-spacing in line '
                              '{}'.format(total_genes+1))
+            expression_ids.add(words[0])
     logging.info("Number of genes in expression matrix: {}".format(total_genes))
+    return expression_ids
 
 
 def check_probe(input_file):
-    probe_size = 0
-    with open(input_file, 'r') as fin:
-        # Make sure there is only one entry/gene per line
-        for line in fin:
-            probe_size += 1  # add one gene to size of probe file
-            size = len(line.split(' '))
-            if size > 1:
-                sys.exit('Error - There are more than one word per line in this probe file')
-    logging.info("Number of hub genes in probe file: {}".format(probe_size))
+    with open(input_file, 'rb') as fin:
+        try:
+            contents = fin.read().decode('utf-8-sig')
+        except UnicodeDecodeError as error:
+            sys.exit('Error - probe file is not valid UTF-8: {}'.format(error))
+
+    probe_ids = []
+    seen = set()
+    duplicate_count = 0
+
+    # Match the C++ hub-list parser: accept LF, CRLF, lone CR, and mixed endings;
+    # trim ASCII boundary whitespace; skip blank records; preserve case and
+    # internal whitespace; and keep the first occurrence of each identifier.
+    for line in re.split(r'\r\n|\r|\n', contents):
+        probe_id = line.strip(BOUNDARY_WHITESPACE)
+        if not probe_id:
+            continue
+        if probe_id in seen:
+            duplicate_count += 1
+            continue
+        seen.add(probe_id)
+        probe_ids.append(probe_id)
+
+    logging.info("Number of unique hub genes in probe file: {}".format(len(probe_ids)))
+    if duplicate_count:
+        logging.info("Duplicate hub genes ignored: {}".format(duplicate_count))
+    return probe_ids, duplicate_count
+
+
+def validate_hub_overlap(expression_ids, probe_ids):
+    matched = [probe_id for probe_id in probe_ids if probe_id in expression_ids]
+    missing = [probe_id for probe_id in probe_ids if probe_id not in expression_ids]
+
+    logging.info(
+        "Hub overlap: requested={}, matched={}, missing={}".format(
+            len(probe_ids), len(matched), len(missing)
+        )
+    )
+
+    if missing:
+        preview = ', '.join(missing[:20])
+        suffix = '' if len(missing) <= 20 else ', ...'
+        logging.warning("Hub genes absent from expression matrix: {}{}".format(preview, suffix))
+
+    if not matched:
+        sys.exit(
+            'Error - zero hub genes from the probe file matched the expression matrix '
+            '(requested: {}). Refusing to start bootstrap jobs.'.format(len(probe_ids))
+        )
+
+    return matched, missing
+
+
+def write_validation_report(output_file, expression_ids, probe_ids, duplicate_count,
+                            matched, missing):
+    with open(output_file, 'w', encoding='utf-8', newline='\n') as fout:
+        fout.write('status\tpassed\n')
+        fout.write('expression_genes\t{}\n'.format(len(expression_ids)))
+        fout.write('hub_genes_requested\t{}\n'.format(len(probe_ids)))
+        fout.write('hub_genes_matched\t{}\n'.format(len(matched)))
+        fout.write('hub_genes_missing\t{}\n'.format(len(missing)))
+        fout.write('hub_duplicates_ignored\t{}\n'.format(duplicate_count))
+        fout.write('matched_hubs\t{}\n'.format(','.join(matched)))
+        fout.write('missing_hubs\t{}\n'.format(','.join(missing)))
+
+
+def validate_inputs(exp_file, probe_file, output_file=DEFAULT_REPORT_FILE):
+    expression_ids = check_exp(exp_file)
+    probe_ids, duplicate_count = check_probe(probe_file)
+    matched, missing = validate_hub_overlap(expression_ids, probe_ids)
+    write_validation_report(
+        output_file, expression_ids, probe_ids, duplicate_count, matched, missing
+    )
+    logging.info("Hub-overlap validation passed; report: {}".format(output_file))
+    return matched, missing
 
 
 if __name__ == '__main__':

--- a/SJARACNe/bin/create_consensus_network.py
+++ b/SJARACNe/bin/create_consensus_network.py
@@ -55,8 +55,9 @@ def create_consensus_network(adjmat_dir, p_value, out_dir):
     total_mi = {}
 
     # Processing all bootstrap networks, summarizing them into corresponding variables
-    for adj_file in os.listdir(adjmat_dir):
-        total_edge_in_runs.append(0)
+    for adj_file in sorted(os.listdir(adjmat_dir)):
+        edges_in_run = {}
+        duplicate_edge_count = 0
         # Opening each bootstrap file
         with open(pathlib.PurePath(adjmat_dir).joinpath(adj_file), "r") as fadj:
             for line in fadj:
@@ -72,21 +73,42 @@ def create_consensus_network(adjmat_dir, p_value, out_dir):
                     # the corresponding value to the edge between the hub gene and the gene with an odd index
                     # appearing before the value in the tokens list
                     for index in range(1, len(tokens), 2):
-                        key = hub_id + "----" + tokens[index]  # Creating a key for the edge
-                        if key in total_edge_number:
-                            # Updating the total number of edges observed for the particular key (edge)
-                            total_edge_number[key] += 1
-                            # Updating total MI between the genes involving in the particular key (edge)
-                            total_mi[key] += float(tokens[index + 1])
-                        else:
-                            # Initializing the total number of edges observed for the particular key (edge)
-                            # if the key (edge) is newly generated
-                            total_edge_number[key] = 1
-                            # Initializing total MI between the genes involving in the particular key (edge)
-                            # if the key (edge) is newly generated
-                            total_mi[key] = float(tokens[index + 1])
-                        # Increment the total number of edges processed so far for a bootstrap run
-                        total_edge_in_runs[bootstrap_run_num] += 1
+                        key = (hub_id, tokens[index])  # Ordered source-target edge
+                        mi = float(tokens[index + 1])
+
+                        if not math.isfinite(mi):
+                            raise ValueError(
+                                "Non-finite MI value for edge {}----{} in bootstrap "
+                                "file '{}': {}".format(key[0], key[1], adj_file, mi)
+                            )
+
+                        if key in edges_in_run:
+                            duplicate_edge_count += 1
+                            if edges_in_run[key] != mi:
+                                raise ValueError(
+                                    "Conflicting MI values for duplicate edge {}----{} in bootstrap "
+                                    "file '{}': {} versus {}".format(
+                                        key[0], key[1], adj_file, edges_in_run[key], mi
+                                    )
+                                )
+                            continue
+
+                        edges_in_run[key] = mi
+
+        if duplicate_edge_count:
+            logging.warning(
+                "Ignored %d duplicate edge occurrence(s) in bootstrap file '%s'",
+                duplicate_edge_count,
+                adj_file,
+            )
+
+        total_edge_in_runs.append(len(edges_in_run))
+        for key, mi in edges_in_run.items():
+            # A bootstrap is one Bernoulli observation for an edge, regardless
+            # of how many times a malformed file repeats that edge.
+            total_edge_number[key] = total_edge_number.get(key, 0) + 1
+            total_mi[key] = total_mi.get(key, 0.0) + mi
+
         # Increment the bootstrap file index
         bootstrap_run_num += 1
 
@@ -128,9 +150,7 @@ def create_consensus_network(adjmat_dir, p_value, out_dir):
         # Iterate over all edges in a sorted fashion
         for key in sorted(total_edge_number.keys()):
             # Extract first two gene involving an edge from the key (edge)
-            tks = key.split('----')
-            gene1 = tks[0]
-            gene2 = tks[1]
+            gene1, gene2 = key
 
             # Compute the z score of normal distribution
             z = float(total_edge_number[key] - mu) / float(sigma) if sigma != 0 else 100

--- a/SJARACNe/cwl/QC_input.cwl
+++ b/SJARACNe/cwl/QC_input.cwl
@@ -11,7 +11,7 @@ requirements:
       - $(inputs.exp_file)
       - $(inputs.probe_file)
 
-baseCommand: QC_input.py
+baseCommand: [python3, -m, SJARACNe.bin.QC_input]
 
 inputs:
   exp_file:

--- a/SJARACNe/cwl/QC_input.cwl
+++ b/SJARACNe/cwl/QC_input.cwl
@@ -26,5 +26,15 @@ inputs:
       position: 2
       prefix: -g
       valueFrom: $(self.basename)
+  output_file:
+    type: string
+    default: hub_overlap_validation.txt
+    inputBinding:
+      position: 3
+      prefix: -o
 
-outputs: []
+outputs:
+  validation_report:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_file)

--- a/SJARACNe/cwl/ch_line_ending.cwl
+++ b/SJARACNe/cwl/ch_line_ending.cwl
@@ -10,7 +10,7 @@ requirements:
     listing:
       - $(inputs.input_file)
 
-baseCommand: ch_line_ending.py
+baseCommand: [python3, -m, SJARACNe.bin.ch_line_ending]
 
 inputs:
   input_file:

--- a/SJARACNe/cwl/create_consensus_network.cwl
+++ b/SJARACNe/cwl/create_consensus_network.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 
-baseCommand: create_consensus_network.py
+baseCommand: [python3, -m, SJARACNe.bin.create_consensus_network]
 
 inputs:
   adjmat_dir:

--- a/SJARACNe/cwl/sjaracne.cwl
+++ b/SJARACNe/cwl/sjaracne.cwl
@@ -7,6 +7,9 @@ doc: Scalable solution of ARACNe that dramatically improves the computational pe
 baseCommand: sjaracne.exe
 
 inputs:
+  preflight_report:
+    type: File?
+    doc: Successful hub-overlap validation report; establishes a workflow dependency before bootstrapping
   exp_file:
     type: File
     inputBinding:

--- a/SJARACNe/cwl/sjaracne_workflow.cwl
+++ b/SJARACNe/cwl/sjaracne_workflow.cwl
@@ -49,7 +49,7 @@ steps:
     in:
       exp_file: exp_file
       probe_file: probe_file
-    out: []
+    out: [validation_report]
 
   # Step 1: create seeds from bootstrap number
   create_seeds:
@@ -83,6 +83,7 @@ steps:
   bootstrap:
     run: sjaracne.cwl
     in:
+      preflight_report: validate_files/validation_report
       exp_file: ch_ending_exp/out_file
       probe_file_tf: ch_ending_probe/out_file
       probe_file_subnetwork: ch_ending_probe/out_file

--- a/SJARACNe/src/main.cpp
+++ b/SJARACNe/src/main.cpp
@@ -124,7 +124,10 @@ Parameter parseParameter(int argc, char *argv[])
       case 'o': p.outfile    = ARGF(); break;            // output file
       case 'p': p.pvalue     = std::atof(ARGF()); break; // p-value
       case 'r': p.sample     = std::atoi(ARGF()); break; // bootstrap sample number
-      case 's': p.subnetfile = ARGF(); break;            // subset of probes
+      case 's': p.subnetfile = ARGF();                   // subset of probes
+                if (p.subnetfile == "")
+                   throw std::string("Option '-s' requires a subnetwork file.");
+                break;
       case 't': p.threshold  = std::atof(ARGF()); break; // mi threshold
       case 'v': p.verbose    = ARGF(); break;            // verbose
       default : throw std::string("unknown parameter ") + ARGC();
@@ -210,11 +213,6 @@ void runStandard(int argc, char *argv[])
                 << std::endl;
    }
 
-   if (p.correction != 0.0)
-      data.computeMarkerVariance(arrays);
-
-   data.computeMarkerBandwidth(arrays);
-
    std::vector<int> ids;
 
    if (p.hub != "")
@@ -232,16 +230,42 @@ void runStandard(int argc, char *argv[])
    }
 
    int numSubnets = p.subnet.size();
+   int numMissingSubnets = 0;
 
    for (int i = 0; i < numSubnets; i++)
    {
       int gid = data.getProbeId(p.subnet[i]);
       if (gid == -1)
+      {
          std::cout << "Cannot find probe: " << p.subnet[i] << " in \""
                    << p.subnetfile << "\" ... ignored." << std::endl;
+         numMissingSubnets++;
+      }
       else
          ids.push_back(gid);
    }
+
+   if (p.subnetfile != "")
+   {
+      std::cout << "[SUBNETWORK] Requested: " << numSubnets
+                << ", matched: " << ids.size()
+                << ", missing: " << numMissingSubnets << std::endl;
+
+      if (ids.size() == 0)
+      {
+         std::ostringstream s;
+         s << "Subnetwork file \"" << p.subnetfile << "\" was supplied, but zero "
+           << "probe IDs matched the first column of \"" << p.infile
+           << "\" (requested: " << numSubnets
+           << "). Refusing to construct an all-gene network.";
+         throw s.str();
+      }
+   }
+
+   if (p.correction != 0.0)
+      data.computeMarkerVariance(arrays);
+
+   data.computeMarkerBandwidth(arrays);
 
    Transfac transfac;
 

--- a/SJARACNe/src/param.cpp
+++ b/SJARACNe/src/param.cpp
@@ -8,7 +8,6 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include "param.h"
 
 //------------------------------------------------------------------------------------
@@ -105,32 +104,62 @@ void checkParameter(Parameter &p)
 }
 
 //------------------------------------------------------------------------------------
-// readProbeList() reads the list of nodes to be included in constructing a subnetwork
+// appendProbeId() normalizes and stores one identifier from a hub-list record.
+
+static void appendProbeId(std::string gid, bool first_record,
+                          std::vector<std::string>& probe_list)
+{
+   const std::string utf8_bom("\xEF\xBB\xBF", 3);
+
+   if (first_record && gid.compare(0, utf8_bom.length(), utf8_bom) == 0)
+      gid.erase(0, utf8_bom.length());
+
+   const std::string whitespace(" \t\n\r\f\v");
+   std::string::size_type first = gid.find_first_not_of(whitespace);
+
+   if (first == std::string::npos)
+      return;
+
+   std::string::size_type last = gid.find_last_not_of(whitespace);
+   gid = gid.substr(first, last - first + 1);
+
+   probe_list.push_back("_" + gid);
+}
+
+//------------------------------------------------------------------------------------
+// readProbeList() reads and normalizes the list of nodes used by -s and -l.
 
 static int readProbeList(const std::string& infilename,
                          std::vector<std::string>& probe_list)
 {
-   std::ifstream in(infilename.c_str());
+   std::ifstream in(infilename.c_str(), std::ios::binary);
    if (!in.is_open())
       throw "Unable to open " + infilename;
 
    std::string line;
-   int lnum = 0;
+   bool first_record = true;
+   char c;
 
-   while (in.good() && in.peek() != EOF && in.peek() != '\012')
+   while (in.get(c))
    {
-      std::getline(in, line);
-      std::istringstream sin(line);
-      std::string gid;
-      std::getline(sin, gid);
-      gid = "_" + gid;
-      probe_list.push_back(gid);
-      lnum++;
+      if (c == '\n' || c == '\r')
+      {
+         appendProbeId(line, first_record, probe_list);
+         line.clear();
+         first_record = false;
+
+         // Consume LF as part of a CRLF delimiter. A lone CR is also a valid
+         // delimiter, which keeps classic Mac and mixed-ending files readable.
+         if (c == '\r' && in.peek() == '\n')
+            in.get(c);
+      }
+      else
+         line += c;
    }
 
-   in.close();
+   appendProbeId(line, first_record, probe_list);
 
-   return lnum;
+   return probe_list.size();
 }
 
 //------------------------------------------------------------------------------------

--- a/SJARACNe/src/param.cpp
+++ b/SJARACNe/src/param.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <set>
 #include "param.h"
 
 //------------------------------------------------------------------------------------
@@ -107,7 +108,9 @@ void checkParameter(Parameter &p)
 // appendProbeId() normalizes and stores one identifier from a hub-list record.
 
 static void appendProbeId(std::string gid, bool first_record,
-                          std::vector<std::string>& probe_list)
+                          std::vector<std::string>& probe_list,
+                          std::set<std::string>& seen,
+                          int& duplicate_count)
 {
    const std::string utf8_bom("\xEF\xBB\xBF", 3);
 
@@ -122,20 +125,29 @@ static void appendProbeId(std::string gid, bool first_record,
 
    std::string::size_type last = gid.find_last_not_of(whitespace);
    gid = gid.substr(first, last - first + 1);
+   gid = "_" + gid;
 
-   probe_list.push_back("_" + gid);
+   if (seen.insert(gid).second)
+      probe_list.push_back(gid);
+   else
+      duplicate_count++;
 }
 
 //------------------------------------------------------------------------------------
 // readProbeList() reads and normalizes the list of nodes used by -s and -l.
 
 static int readProbeList(const std::string& infilename,
-                         std::vector<std::string>& probe_list)
+                         std::vector<std::string>& probe_list,
+                         int& duplicate_count)
 {
    std::ifstream in(infilename.c_str(), std::ios::binary);
    if (!in.is_open())
       throw "Unable to open " + infilename;
 
+   probe_list.clear();
+   duplicate_count = 0;
+
+   std::set<std::string> seen;
    std::string line;
    bool first_record = true;
    char c;
@@ -144,7 +156,7 @@ static int readProbeList(const std::string& infilename,
    {
       if (c == '\n' || c == '\r')
       {
-         appendProbeId(line, first_record, probe_list);
+         appendProbeId(line, first_record, probe_list, seen, duplicate_count);
          line.clear();
          first_record = false;
 
@@ -157,7 +169,7 @@ static int readProbeList(const std::string& infilename,
          line += c;
    }
 
-   appendProbeId(line, first_record, probe_list);
+   appendProbeId(line, first_record, probe_list, seen, duplicate_count);
 
    return probe_list.size();
 }
@@ -183,8 +195,16 @@ void displayParameter(Parameter &p)
                 << p.correction << ")" << std::endl;
 
    if (p.subnetfile != "")
+   {
+      int duplicate_count = 0;
       std::cout << "[PARA] Subset of probes to reconstruct: " << p.subnetfile
-                << " (" << readProbeList(p.subnetfile, p.subnet) << ")" << std::endl;
+                << " (" << readProbeList(p.subnetfile, p.subnet, duplicate_count)
+                << ")" << std::endl;
+
+      if (duplicate_count > 0)
+         std::cout << "[PARA] Duplicate subnetwork probes ignored: "
+                   << duplicate_count << std::endl;
+   }
 
    if (p.hub != "")
       std::cout << "[PARA] Hub probe to reconstruct: " << p.hub << std::endl;
@@ -197,8 +217,16 @@ void displayParameter(Parameter &p)
    }
 
    if (p.annotfile != "")
+   {
+      int duplicate_count = 0;
       std::cout << "[PARA] TF annotation list: " << p.annotfile
-                << " (" << readProbeList(p.annotfile, p.tf_list) << ")" << std::endl;
+                << " (" << readProbeList(p.annotfile, p.tf_list, duplicate_count)
+                << ")" << std::endl;
+
+      if (duplicate_count > 0)
+         std::cout << "[PARA] Duplicate TF annotation probes ignored: "
+                   << duplicate_count << std::endl;
+   }
 
    if (p.mean != 0.0 || p.cv != 0.0)
    {

--- a/tests/test_create_consensus_network.py
+++ b/tests/test_create_consensus_network.py
@@ -4,6 +4,7 @@ import unittest
 import filecmp
 import tempfile
 import sys
+from pathlib import Path
 from SJARACNe.bin.create_consensus_network import create_consensus_network as cn
 from SJARACNe.bin.create_consensus_network import create_enhanced_consensus_network as ecn
 from SJARACNe.bin.create_consensus_network import uprob
@@ -50,6 +51,117 @@ class TestConsensusNetwork(unittest.TestCase):
 
     def test_uprob_neg1(self):
         self.assertAlmostEqual(0.841344680778, uprob(-1))
+
+
+class TestConsensusDuplicateEdges(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    @staticmethod
+    def write_bootstrap(directory, filename, body):
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / filename).write_text(
+            ">  Input file test.exp\n" + body,
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def read_network(output_dir):
+        return (output_dir / "consensus_network_3col_.txt").read_text(
+            encoding="utf-8"
+        )
+
+    def test_duplicate_edge_occurrences_count_once_per_bootstrap(self):
+        clean_dir = self.workdir / "clean"
+        duplicate_dir = self.workdir / "duplicate"
+        clean_output = self.workdir / "clean_output"
+        duplicate_output = self.workdir / "duplicate_output"
+
+        self.write_bootstrap(clean_dir, "run_1.adj", "A\tB\t0.5\tC\t0.2\n")
+        self.write_bootstrap(clean_dir, "run_2.adj", "A\tB\t0.7\n")
+        self.write_bootstrap(
+            duplicate_dir,
+            "run_1.adj",
+            "A\tB\t0.5\tB\t0.5\tC\t0.2\nA\tB\t0.5\n",
+        )
+        self.write_bootstrap(duplicate_dir, "run_2.adj", "A\tB\t0.7\n")
+
+        cn(clean_dir, 1.0, clean_output)
+        with self.assertLogs(level="WARNING") as logs:
+            cn(duplicate_dir, 1.0, duplicate_output)
+
+        self.assertIn("Ignored 2 duplicate edge occurrence(s)", "\n".join(logs.output))
+        self.assertEqual(
+            self.read_network(duplicate_output), self.read_network(clean_output)
+        )
+        self.assertIn("A\tB\t0.6000\n", self.read_network(duplicate_output))
+        self.assertEqual(
+            (duplicate_output / "bootstrap_info_.txt").read_text(encoding="utf-8"),
+            (clean_output / "bootstrap_info_.txt").read_text(encoding="utf-8"),
+        )
+
+    def test_conflicting_duplicate_mi_values_fail_closed(self):
+        adjacency_dir = self.workdir / "conflicting"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(
+            adjacency_dir,
+            "run_1.adj",
+            "A\tB\t0.5\nA\tB\t0.6\n",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Conflicting MI values for duplicate edge A----B.*0.5 versus 0.6",
+        ):
+            cn(adjacency_dir, 1.0, output_dir)
+
+        self.assertFalse((output_dir / "consensus_network_3col_.txt").exists())
+
+    def test_equivalent_mi_text_is_an_exact_numeric_duplicate(self):
+        adjacency_dir = self.workdir / "equivalent"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(
+            adjacency_dir,
+            "run_1.adj",
+            "A\tB\t0.5\nA\tB\t0.5000\n",
+        )
+
+        with self.assertLogs(level="WARNING"):
+            cn(adjacency_dir, 1.0, output_dir)
+
+        self.assertIn("A\tB\t0.5000\n", self.read_network(output_dir))
+
+    def test_nonfinite_mi_fails_closed(self):
+        adjacency_dir = self.workdir / "nonfinite"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(adjacency_dir, "run_1.adj", "A\tB\tnan\n")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Non-finite MI value for edge A----B.*nan",
+        ):
+            cn(adjacency_dir, 1.0, output_dir)
+
+        self.assertFalse((output_dir / "consensus_network_3col_.txt").exists())
+
+    def test_reverse_ordered_edge_is_not_treated_as_a_duplicate(self):
+        adjacency_dir = self.workdir / "directed"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(
+            adjacency_dir,
+            "run_1.adj",
+            "A\tB\t0.5\nB\tA\t0.7\n",
+        )
+
+        cn(adjacency_dir, 1.0, output_dir)
+
+        network = self.read_network(output_dir)
+        self.assertIn("A\tB\t0.5000\n", network)
+        self.assertIn("B\tA\t0.7000\n", network)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_qc_input.py
+++ b/tests/test_qc_input.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+QC_SCRIPT = PROJECT_ROOT / "SJARACNe" / "bin" / "QC_input.py"
+
+
+class TestQCInput(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+        self.expression = self.workdir / "small.exp"
+        self.expression.write_text(
+            "isoformId\tgeneSymbol\ts1\ts2\n"
+            "A\tA\t1\t2\n"
+            "B\tB\t2\t1\n"
+            "C\tC\t3\t4\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    def run_qc(self, probe_file):
+        report = self.workdir / "hub_overlap_validation.txt"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(QC_SCRIPT),
+                "-e",
+                str(self.expression),
+                "-g",
+                str(probe_file),
+                "-o",
+                str(report),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result, report
+
+    @staticmethod
+    def read_report(report):
+        return dict(
+            line.split("\t", 1)
+            for line in report.read_text(encoding="utf-8").splitlines()
+        )
+
+    def test_partial_overlap_passes_and_reports_normalized_unique_hubs(self):
+        probes = self.workdir / "partial_hubs.txt"
+        probes.write_bytes(b"\xef\xbb\xbf A \r\n\r\n\tA\t\rMISSING\n")
+
+        result, report = self.run_qc(probes)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(report.is_file())
+        self.assertIn("Hub overlap: requested=2, matched=1, missing=1", result.stderr)
+        self.assertEqual(
+            self.read_report(report),
+            {
+                "status": "passed",
+                "expression_genes": "3",
+                "hub_genes_requested": "2",
+                "hub_genes_matched": "1",
+                "hub_genes_missing": "1",
+                "hub_duplicates_ignored": "1",
+                "matched_hubs": "A",
+                "missing_hubs": "MISSING",
+            },
+        )
+
+    def test_zero_overlap_fails_before_creating_validation_report(self):
+        probes = self.workdir / "unresolved_hubs.txt"
+        probes.write_text("NOT_PRESENT\nNOT_PRESENT\n", encoding="utf-8")
+
+        result, report = self.run_qc(probes)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requested=1, matched=0, missing=1", result.stderr)
+        self.assertIn("Refusing to start bootstrap jobs", result.stderr)
+        self.assertFalse(report.exists())
+
+    def test_blank_hub_file_fails_before_creating_validation_report(self):
+        probes = self.workdir / "blank_hubs.txt"
+        probes.write_text(" \n\t\r\n", encoding="utf-8")
+
+        result, report = self.run_qc(probes)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requested=0, matched=0, missing=0", result.stderr)
+        self.assertIn("Refusing to start bootstrap jobs", result.stderr)
+        self.assertFalse(report.exists())
+
+    def test_bootstrap_has_hard_dependency_on_validation_report(self):
+        workflow = (
+            PROJECT_ROOT / "SJARACNe" / "cwl" / "sjaracne_workflow.cwl"
+        ).read_text(encoding="utf-8")
+        qc_tool = (PROJECT_ROOT / "SJARACNe" / "cwl" / "QC_input.cwl").read_text(
+            encoding="utf-8"
+        )
+        bootstrap_tool = (
+            PROJECT_ROOT / "SJARACNe" / "cwl" / "sjaracne.cwl"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("out: [validation_report]", workflow)
+        self.assertIn(
+            "preflight_report: validate_files/validation_report", workflow
+        )
+        self.assertIn(
+            "validation_report:\n    type: File\n    outputBinding:", qc_tool
+        )
+        self.assertIn(
+            "preflight_report:\n    type: File?\n    doc:", bootstrap_tool
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qc_input.py
+++ b/tests/test_qc_input.py
@@ -120,6 +120,25 @@ class TestQCInput(unittest.TestCase):
             "preflight_report:\n    type: File?\n    doc:", bootstrap_tool
         )
 
+    def test_active_python_cwl_tools_do_not_depend_on_script_shebangs(self):
+        cwl_dir = PROJECT_ROOT / "SJARACNe" / "cwl"
+        expected_commands = {
+            "QC_input.cwl": "baseCommand: [python3, -m, SJARACNe.bin.QC_input]",
+            "ch_line_ending.cwl": (
+                "baseCommand: [python3, -m, SJARACNe.bin.ch_line_ending]"
+            ),
+            "create_consensus_network.cwl": (
+                "baseCommand: [python3, -m, SJARACNe.bin.create_consensus_network]"
+            ),
+        }
+
+        for filename, expected in expected_commands.items():
+            with self.subTest(filename=filename):
+                self.assertIn(
+                    expected,
+                    (cwl_dir / filename).read_text(encoding="utf-8"),
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sjaracne_subnetwork_resolution.py
+++ b/tests/test_sjaracne_subnetwork_resolution.py
@@ -108,6 +108,43 @@ class TestSubnetworkResolution(unittest.TestCase):
         self.assertNotIn("Cannot find probe", result.stdout)
         self.assertTrue(output.is_file())
 
+    def test_duplicate_subnetwork_hubs_are_computed_and_written_once(self):
+        hubs = self.workdir / "duplicate_hubs.txt"
+        hubs.write_bytes(b"A\n A \r\n\tA\t\r")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"Subset of probes to reconstruct: {hubs} (1)", result.stdout)
+        self.assertIn("Duplicate subnetwork probes ignored: 2", result.stdout)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 1, matched: 1, missing: 0", result.stdout
+        )
+        self.assertIn("Gene: 1", result.stdout)
+
+        source_rows = [
+            line
+            for line in output.read_text(encoding="utf-8").splitlines()
+            if line.split("\t", 1)[0] == "A"
+        ]
+        self.assertEqual(len(source_rows), 1)
+
+    def test_duplicate_tf_annotation_hubs_are_deduplicated(self):
+        subnet = self.workdir / "single_hub.txt"
+        subnet.write_text("A\n", encoding="utf-8")
+        tf_hubs = self.workdir / "duplicate_tf_hubs.txt"
+        tf_hubs.write_bytes(b"A\r\n A \nB\r\n\tB\t\r")
+
+        result, output = self.run_sjaracne(
+            "-s", str(subnet), "-l", str(tf_hubs)
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"[PARA] TF annotation list: {tf_hubs} (2)", result.stdout)
+        self.assertIn("Duplicate TF annotation probes ignored: 2", result.stdout)
+        self.assertNotIn("Cannot find probe", result.stdout)
+        self.assertTrue(output.is_file())
+
     def test_unresolved_subnetwork_fails_instead_of_running_all_genes(self):
         hubs = self.workdir / "missing_hubs.txt"
         hubs.write_text("NOT_IN_EXPRESSION\n", encoding="utf-8")

--- a/tests/test_sjaracne_subnetwork_resolution.py
+++ b/tests/test_sjaracne_subnetwork_resolution.py
@@ -80,6 +80,34 @@ class TestSubnetworkResolution(unittest.TestCase):
         self.assertIn("Gene: 1", result.stdout)
         self.assertTrue(output.is_file())
 
+    def test_subnetwork_list_normalizes_bom_whitespace_blank_lines_and_endings(self):
+        hubs = self.workdir / "normalized_hubs.txt"
+        hubs.write_bytes(b"\xef\xbb\xbf  A  \r\n\r\n\tB\t\r C \n")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 3, matched: 3, missing: 0", result.stdout
+        )
+        self.assertIn("Gene: 3", result.stdout)
+        self.assertNotIn("Cannot find probe", result.stdout)
+        self.assertTrue(output.is_file())
+
+    def test_tf_annotation_list_uses_the_same_normalization(self):
+        hubs = self.workdir / "normalized_tf_hubs.txt"
+        hubs.write_bytes(b"\xef\xbb\xbf\tA \r\n\r\n B\t\r")
+
+        result, output = self.run_sjaracne("-s", str(hubs), "-l", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"[PARA] TF annotation list: {hubs} (2)", result.stdout)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 2, matched: 2, missing: 0", result.stdout
+        )
+        self.assertNotIn("Cannot find probe", result.stdout)
+        self.assertTrue(output.is_file())
+
     def test_unresolved_subnetwork_fails_instead_of_running_all_genes(self):
         hubs = self.workdir / "missing_hubs.txt"
         hubs.write_text("NOT_IN_EXPRESSION\n", encoding="utf-8")

--- a/tests/test_sjaracne_subnetwork_resolution.py
+++ b/tests/test_sjaracne_subnetwork_resolution.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def find_sjaracne_executable():
+    configured = os.environ.get("SJARACNE_TEST_EXE")
+    candidates = [
+        configured,
+        Path(__file__).resolve().parents[1] / "SJARACNe" / "bin" / "sjaracne.exe",
+        shutil.which("sjaracne.exe"),
+    ]
+
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return str(candidate)
+    return None
+
+
+SJARACNE_EXE = find_sjaracne_executable()
+
+
+@unittest.skipUnless(SJARACNE_EXE, "sjaracne.exe is not built")
+class TestSubnetworkResolution(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+        self.expression = self.workdir / "small.exp"
+        self.expression.write_text(
+            "isoformId\tgeneSymbol\ts1\ts2\ts3\ts4\ts5\ts6\n"
+            "A\tA\t1\t2\t3\t4\t5\t6\n"
+            "B\tB\t6\t5\t4\t3\t2\t1\n"
+            "C\tC\t1\t3\t2\t6\t4\t5\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    def run_sjaracne(self, *extra_args):
+        output = self.workdir / "network.adj"
+        command = [
+            SJARACNE_EXE,
+            "-i",
+            str(self.expression),
+            "-p",
+            "1",
+            "-e",
+            "1",
+            "-o",
+            str(output),
+            *extra_args,
+        ]
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+        return result, output
+
+    def test_omitted_subnetwork_retains_all_gene_mode(self):
+        result, output = self.run_sjaracne()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Gene: 3", result.stdout)
+        self.assertNotIn("[SUBNETWORK]", result.stdout)
+        self.assertTrue(output.is_file())
+
+    def test_partial_subnetwork_match_continues_with_summary(self):
+        hubs = self.workdir / "partial_hubs.txt"
+        hubs.write_text("A\nNOT_IN_EXPRESSION\n", encoding="utf-8")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 2, matched: 1, missing: 1", result.stdout
+        )
+        self.assertIn("Gene: 1", result.stdout)
+        self.assertTrue(output.is_file())
+
+    def test_unresolved_subnetwork_fails_instead_of_running_all_genes(self):
+        hubs = self.workdir / "missing_hubs.txt"
+        hubs.write_text("NOT_IN_EXPRESSION\n", encoding="utf-8")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("zero probe IDs matched", result.stderr)
+        self.assertIn("(requested: 1)", result.stderr)
+        self.assertIn("Refusing to construct an all-gene network", result.stderr)
+        self.assertNotIn("Gene: 3", result.stdout)
+        self.assertFalse(output.exists())
+
+    def test_empty_subnetwork_file_fails_instead_of_running_all_genes(self):
+        hubs = self.workdir / "empty_hubs.txt"
+        hubs.write_text("", encoding="utf-8")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("zero probe IDs matched", result.stderr)
+        self.assertIn("(requested: 0)", result.stderr)
+        self.assertNotIn("Gene: 3", result.stdout)
+        self.assertFalse(output.exists())
+
+    def test_subnetwork_option_without_file_is_rejected(self):
+        result, output = self.run_sjaracne("-s")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Option '-s' requires a subnetwork file", result.stderr)
+        self.assertNotIn("Gene: 3", result.stdout)
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Replacement for #59. GitHub automatically closed that PR when its source fork was deleted; recreating a fork with the same name does not reconnect the deleted repository identity.

## Summary

This PR fixes five potential failures in hub selection, workflow preflight, and consensus aggregation. It also makes the active Python CWL tools runnable from WSL when the checkout uses Windows line endings.

### 1. Fail closed when a supplied subnetwork resolves to no genes (`6542702`)

**Previous risk:** An empty or completely unmatched `-s` list produced an empty internal hub-ID vector. SJARACNe also uses an empty vector for intentional all-gene mode, so a blank or mistyped hub list could silently launch a much larger, scientifically different network.

**New behavior:**

- Omitting `-s` still retains the intentional all-gene behavior.
- Supplying `-s` without a filename is rejected with a clear error.
- A partially matched list continues using only the matched hubs and reports requested, matched, and missing counts.
- A supplied list with zero matches stops before bandwidth/variance preparation or network output.

### 2. Normalize `-s` and `-l` hub-list input (`439afe4`)

**Previous risk:** UTF-8 BOMs, CRLF or classic-Mac CR endings, mixed line endings, surrounding whitespace, blank records, and a final unterminated record could create false missing hubs or stop parsing early.

**New behavior:** Both subnetwork (`-s`) and TF-annotation (`-l`) lists now:

- accept LF, CRLF, lone CR, and mixed line endings;
- remove an initial UTF-8 BOM;
- trim ASCII whitespace around identifiers;
- skip blank records; and
- retain a final record without a trailing newline.

Identifier case and internal content are preserved.

### 3. Deduplicate hub identifiers (`3b8dad0`)

**Previous risk:** Repeated normalized IDs could recompute and write the same hub row multiple times and could later inflate consensus support.

**New behavior:** Both `-s` and `-l` keep only the first occurrence of each normalized, case-sensitive ID, preserve first-occurrence order, and report how many duplicates were ignored.

### 4. Validate hub overlap before bootstrap scatter (`53780fe`)

**Previous risk:** Workflow QC checked expression-file shape but did not verify that any requested hub existed in the expression matrix. Bootstrap jobs also had no hard dependency on successful overlap validation, so an invalid list could launch every scattered bootstrap job before failing-or could trigger unintended all-gene behavior.

**New behavior:**

- Preflight applies the same hub normalization and deduplication rules used by the native executable.
- It compares requested hubs with expression-matrix row IDs and reports requested, matched, and missing hubs.
- Partial overlap is allowed and documented in a validation report.
- Blank or zero-overlap lists fail before a validation report is produced.
- The successful validation report is an explicit CWL input to every bootstrap job, so failed preflight prevents the bootstrap scatter from starting.

### 5. Count each ordered edge at most once per bootstrap (`440b0bc`)

**Previous risk:** Duplicate adjacency entries within one bootstrap were counted as independent edge recurrences. That inflated support, could bias average MI, and corrupted the per-run edge counts used by the consensus null model. One bootstrap should contribute one Bernoulli support observation per edge.

**New behavior:**

- Each bootstrap contributes at most one support count and one MI value for each ordered `(source, target)` edge.
- Numerically identical duplicates are ignored and summarized in one warning per file.
- Conflicting duplicate MI values and non-finite MI values fail closed.
- Reverse edges remain distinct: `(A, B)` is not deduplicated with `(B, A)`.
- Bootstrap files are processed deterministically.
- Consensus MI remains the mean across the bootstrap runs in which the edge appears.

## WSL compatibility (`759104f`)

The three active Python CWL tools now run as `python3 -m SJARACNe.bin.<module>` instead of executing checkout scripts through their shebangs. This avoids `python3\r` shebang failures when a Windows checkout is executed in WSL. SJARACNe must be installed in the active Python environment so those modules can be resolved.

## Validation

- 19/19 combined regression tests passed in the isolated WSL environment: 9 native subnetwork-resolution tests, 5 QC/CWL tests, and 5 consensus duplicate-edge tests.
- 12/12 focused consensus tests passed on Windows, including the existing golden-output checks.
- An installed one-bootstrap T-cell CWL workflow completed successfully in WSL.
- A zero-overlap workflow failed during preflight before any bootstrap job started.

## Scope

This PR intentionally does not include the deferred DPI and performance optimizations.