### PR TITLE
Harden adjacency loading, empty networks, and expression/MI validation

### DIFF
--- a/SJARACNe/bin/QC_input.py
+++ b/SJARACNe/bin/QC_input.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 
 import argparse
-import sys
 import logging
+import re
+import sys
+
+
+DEFAULT_REPORT_FILE = 'hub_overlap_validation.txt'
+BOUNDARY_WHITESPACE = ' \t\n\r\f\v'
 
 
 def main():
@@ -10,25 +15,29 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description=head_description)
     parser.add_argument('-e', '--exp-file', metavar='STR', required=True, help='exp file')
     parser.add_argument('-g', '--probe-file', metavar='STR', required=True, help='probe file')
+    parser.add_argument('-o', '--output-file', metavar='STR', default=DEFAULT_REPORT_FILE,
+                        help='output validation report')
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
 
-    check_exp(args.exp_file)
-    check_probe(args.probe_file)
+    validate_inputs(args.exp_file, args.probe_file, args.output_file)
 
 
 def check_exp(input_file):
     total_genes = 0
-    with open(input_file, 'r') as fin:
+    expression_ids = set()
+
+    with open(input_file, 'r', encoding='utf-8-sig', newline=None) as fin:
         # process header
-        header = fin.readline()
+        header = fin.readline().rstrip('\r\n')
         words = header.split('\t')
-        if words[0] != 'isoformId' or words[1] != 'geneSymbol':
+        if len(words) < 2 or words[0] != 'isoformId' or words[1] != 'geneSymbol':
             sys.exit('Error - Improper header in input file: first two column names must be isoformId and '
                      'geneSymbol respectively.')
         entries_per_line = len(words)
         # process rest of the file, making sure tabs are splitting entries
         for line in fin:
+            line = line.rstrip('\r\n')
             words = line.split('\t')
             total_genes += 1  # add one gene to the total count per line of the exp file
             if len(words) != entries_per_line:
@@ -44,19 +53,87 @@ def check_exp(input_file):
                     logging.info("Numeric entry missing spacing is: {}".format(word))
                     sys.exit('Error - There are some numeric entries missing tab-spacing in line '
                              '{}'.format(total_genes+1))
+            expression_ids.add(words[0])
     logging.info("Number of genes in expression matrix: {}".format(total_genes))
+    return expression_ids
 
 
 def check_probe(input_file):
-    probe_size = 0
-    with open(input_file, 'r') as fin:
-        # Make sure there is only one entry/gene per line
-        for line in fin:
-            probe_size += 1  # add one gene to size of probe file
-            size = len(line.split(' '))
-            if size > 1:
-                sys.exit('Error - There are more than one word per line in this probe file')
-    logging.info("Number of hub genes in probe file: {}".format(probe_size))
+    with open(input_file, 'rb') as fin:
+        try:
+            contents = fin.read().decode('utf-8-sig')
+        except UnicodeDecodeError as error:
+            sys.exit('Error - probe file is not valid UTF-8: {}'.format(error))
+
+    probe_ids = []
+    seen = set()
+    duplicate_count = 0
+
+    # Match the C++ hub-list parser: accept LF, CRLF, lone CR, and mixed endings;
+    # trim ASCII boundary whitespace; skip blank records; preserve case and
+    # internal whitespace; and keep the first occurrence of each identifier.
+    for line in re.split(r'\r\n|\r|\n', contents):
+        probe_id = line.strip(BOUNDARY_WHITESPACE)
+        if not probe_id:
+            continue
+        if probe_id in seen:
+            duplicate_count += 1
+            continue
+        seen.add(probe_id)
+        probe_ids.append(probe_id)
+
+    logging.info("Number of unique hub genes in probe file: {}".format(len(probe_ids)))
+    if duplicate_count:
+        logging.info("Duplicate hub genes ignored: {}".format(duplicate_count))
+    return probe_ids, duplicate_count
+
+
+def validate_hub_overlap(expression_ids, probe_ids):
+    matched = [probe_id for probe_id in probe_ids if probe_id in expression_ids]
+    missing = [probe_id for probe_id in probe_ids if probe_id not in expression_ids]
+
+    logging.info(
+        "Hub overlap: requested={}, matched={}, missing={}".format(
+            len(probe_ids), len(matched), len(missing)
+        )
+    )
+
+    if missing:
+        preview = ', '.join(missing[:20])
+        suffix = '' if len(missing) <= 20 else ', ...'
+        logging.warning("Hub genes absent from expression matrix: {}{}".format(preview, suffix))
+
+    if not matched:
+        sys.exit(
+            'Error - zero hub genes from the probe file matched the expression matrix '
+            '(requested: {}). Refusing to start bootstrap jobs.'.format(len(probe_ids))
+        )
+
+    return matched, missing
+
+
+def write_validation_report(output_file, expression_ids, probe_ids, duplicate_count,
+                            matched, missing):
+    with open(output_file, 'w', encoding='utf-8', newline='\n') as fout:
+        fout.write('status\tpassed\n')
+        fout.write('expression_genes\t{}\n'.format(len(expression_ids)))
+        fout.write('hub_genes_requested\t{}\n'.format(len(probe_ids)))
+        fout.write('hub_genes_matched\t{}\n'.format(len(matched)))
+        fout.write('hub_genes_missing\t{}\n'.format(len(missing)))
+        fout.write('hub_duplicates_ignored\t{}\n'.format(duplicate_count))
+        fout.write('matched_hubs\t{}\n'.format(','.join(matched)))
+        fout.write('missing_hubs\t{}\n'.format(','.join(missing)))
+
+
+def validate_inputs(exp_file, probe_file, output_file=DEFAULT_REPORT_FILE):
+    expression_ids = check_exp(exp_file)
+    probe_ids, duplicate_count = check_probe(probe_file)
+    matched, missing = validate_hub_overlap(expression_ids, probe_ids)
+    write_validation_report(
+        output_file, expression_ids, probe_ids, duplicate_count, matched, missing
+    )
+    logging.info("Hub-overlap validation passed; report: {}".format(output_file))
+    return matched, missing
 
 
 if __name__ == '__main__':

--- a/SJARACNe/bin/create_consensus_network.py
+++ b/SJARACNe/bin/create_consensus_network.py
@@ -112,24 +112,38 @@ def create_consensus_network(adjmat_dir, p_value, out_dir):
         # Increment the bootstrap file index
         bootstrap_run_num += 1
 
-    mu = 0
-    sigma = 0
+    if bootstrap_run_num == 0:
+        raise ValueError(
+            "No bootstrap adjacency files found in '{}'.".format(adjmat_dir)
+        )
+
+    edge_count = len(total_edge_number)
+    mu = 0.0
+    sigma = 0.0
     # Computing mu and sigma across all bootstrap files
-    for i in range(0, bootstrap_run_num):
-        prob = float(total_edge_in_runs[i]) / float(len(total_edge_number))
-        mu += prob
-        sigma += prob * (1 - prob)
+    if edge_count > 0:
+        for i in range(0, bootstrap_run_num):
+            prob = float(total_edge_in_runs[i]) / float(edge_count)
+            mu += prob
+            sigma += prob * (1 - prob)
     sigma = np.sqrt(sigma)
+
+    if edge_count > 0:
+        bonferroni_alpha = 0.05 / edge_count
+        bonferroni_alpha_text = str(bonferroni_alpha)
+    else:
+        bonferroni_alpha = None
+        bonferroni_alpha_text = 'N/A (no edges tested)'
 
     # Writing out the summary of all bootstrap files into bootstrap_info.txt file
     with open(pathlib.PurePath(out_dir).joinpath('bootstrap_info_.txt'), 'w') as f_info:
-        f_info.write('Total edge tested: {}\n'.format(str(len(total_edge_number))))
-        f_info.write('Bonferroni corrected (0.05) alpha: {}\n'.format(str(0.05 / len(total_edge_number))))
+        f_info.write('Total edge tested: {}\n'.format(str(edge_count)))
+        f_info.write('Bonferroni corrected (0.05) alpha: {}\n'.format(bonferroni_alpha_text))
         f_info.write('mu: {}\n'.format(str(mu)))
         f_info.write('sigma: {}\n'.format(str(sigma)))
 
     # Setting p_threshold to the given value, if no given value, set to Bonferroni corrected value
-    p_threshold = 0.05 / len(total_edge_number)
+    p_threshold = bonferroni_alpha
     if p_value is not None:
         p_threshold = float(p_value)
 

--- a/SJARACNe/bin/create_consensus_network.py
+++ b/SJARACNe/bin/create_consensus_network.py
@@ -55,8 +55,9 @@ def create_consensus_network(adjmat_dir, p_value, out_dir):
     total_mi = {}
 
     # Processing all bootstrap networks, summarizing them into corresponding variables
-    for adj_file in os.listdir(adjmat_dir):
-        total_edge_in_runs.append(0)
+    for adj_file in sorted(os.listdir(adjmat_dir)):
+        edges_in_run = {}
+        duplicate_edge_count = 0
         # Opening each bootstrap file
         with open(pathlib.PurePath(adjmat_dir).joinpath(adj_file), "r") as fadj:
             for line in fadj:
@@ -72,21 +73,42 @@ def create_consensus_network(adjmat_dir, p_value, out_dir):
                     # the corresponding value to the edge between the hub gene and the gene with an odd index
                     # appearing before the value in the tokens list
                     for index in range(1, len(tokens), 2):
-                        key = hub_id + "----" + tokens[index]  # Creating a key for the edge
-                        if key in total_edge_number:
-                            # Updating the total number of edges observed for the particular key (edge)
-                            total_edge_number[key] += 1
-                            # Updating total MI between the genes involving in the particular key (edge)
-                            total_mi[key] += float(tokens[index + 1])
-                        else:
-                            # Initializing the total number of edges observed for the particular key (edge)
-                            # if the key (edge) is newly generated
-                            total_edge_number[key] = 1
-                            # Initializing total MI between the genes involving in the particular key (edge)
-                            # if the key (edge) is newly generated
-                            total_mi[key] = float(tokens[index + 1])
-                        # Increment the total number of edges processed so far for a bootstrap run
-                        total_edge_in_runs[bootstrap_run_num] += 1
+                        key = (hub_id, tokens[index])  # Ordered source-target edge
+                        mi = float(tokens[index + 1])
+
+                        if not math.isfinite(mi):
+                            raise ValueError(
+                                "Non-finite MI value for edge {}----{} in bootstrap "
+                                "file '{}': {}".format(key[0], key[1], adj_file, mi)
+                            )
+
+                        if key in edges_in_run:
+                            duplicate_edge_count += 1
+                            if edges_in_run[key] != mi:
+                                raise ValueError(
+                                    "Conflicting MI values for duplicate edge {}----{} in bootstrap "
+                                    "file '{}': {} versus {}".format(
+                                        key[0], key[1], adj_file, edges_in_run[key], mi
+                                    )
+                                )
+                            continue
+
+                        edges_in_run[key] = mi
+
+        if duplicate_edge_count:
+            logging.warning(
+                "Ignored %d duplicate edge occurrence(s) in bootstrap file '%s'",
+                duplicate_edge_count,
+                adj_file,
+            )
+
+        total_edge_in_runs.append(len(edges_in_run))
+        for key, mi in edges_in_run.items():
+            # A bootstrap is one Bernoulli observation for an edge, regardless
+            # of how many times a malformed file repeats that edge.
+            total_edge_number[key] = total_edge_number.get(key, 0) + 1
+            total_mi[key] = total_mi.get(key, 0.0) + mi
+
         # Increment the bootstrap file index
         bootstrap_run_num += 1
 
@@ -128,9 +150,7 @@ def create_consensus_network(adjmat_dir, p_value, out_dir):
         # Iterate over all edges in a sorted fashion
         for key in sorted(total_edge_number.keys()):
             # Extract first two gene involving an edge from the key (edge)
-            tks = key.split('----')
-            gene1 = tks[0]
-            gene2 = tks[1]
+            gene1, gene2 = key
 
             # Compute the z score of normal distribution
             z = float(total_edge_number[key] - mu) / float(sigma) if sigma != 0 else 100

--- a/SJARACNe/cwl/QC_input.cwl
+++ b/SJARACNe/cwl/QC_input.cwl
@@ -11,7 +11,7 @@ requirements:
       - $(inputs.exp_file)
       - $(inputs.probe_file)
 
-baseCommand: QC_input.py
+baseCommand: [python3, -m, SJARACNe.bin.QC_input]
 
 inputs:
   exp_file:

--- a/SJARACNe/cwl/QC_input.cwl
+++ b/SJARACNe/cwl/QC_input.cwl
@@ -26,5 +26,15 @@ inputs:
       position: 2
       prefix: -g
       valueFrom: $(self.basename)
+  output_file:
+    type: string
+    default: hub_overlap_validation.txt
+    inputBinding:
+      position: 3
+      prefix: -o
 
-outputs: []
+outputs:
+  validation_report:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_file)

--- a/SJARACNe/cwl/ch_line_ending.cwl
+++ b/SJARACNe/cwl/ch_line_ending.cwl
@@ -10,7 +10,7 @@ requirements:
     listing:
       - $(inputs.input_file)
 
-baseCommand: ch_line_ending.py
+baseCommand: [python3, -m, SJARACNe.bin.ch_line_ending]
 
 inputs:
   input_file:

--- a/SJARACNe/cwl/create_consensus_network.cwl
+++ b/SJARACNe/cwl/create_consensus_network.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 
-baseCommand: create_consensus_network.py
+baseCommand: [python3, -m, SJARACNe.bin.create_consensus_network]
 
 inputs:
   adjmat_dir:

--- a/SJARACNe/cwl/sjaracne.cwl
+++ b/SJARACNe/cwl/sjaracne.cwl
@@ -7,6 +7,9 @@ doc: Scalable solution of ARACNe that dramatically improves the computational pe
 baseCommand: sjaracne.exe
 
 inputs:
+  preflight_report:
+    type: File?
+    doc: Successful hub-overlap validation report; establishes a workflow dependency before bootstrapping
   exp_file:
     type: File
     inputBinding:

--- a/SJARACNe/cwl/sjaracne_workflow.cwl
+++ b/SJARACNe/cwl/sjaracne_workflow.cwl
@@ -49,7 +49,7 @@ steps:
     in:
       exp_file: exp_file
       probe_file: probe_file
-    out: []
+    out: [validation_report]
 
   # Step 1: create seeds from bootstrap number
   create_seeds:
@@ -83,6 +83,7 @@ steps:
   bootstrap:
     run: sjaracne.cwl
     in:
+      preflight_report: validate_files/validation_report
       exp_file: ch_ending_exp/out_file
       probe_file_tf: ch_ending_probe/out_file
       probe_file_subnetwork: ch_ending_probe/out_file

--- a/SJARACNe/src/main.cpp
+++ b/SJARACNe/src/main.cpp
@@ -124,7 +124,10 @@ Parameter parseParameter(int argc, char *argv[])
       case 'o': p.outfile    = ARGF(); break;            // output file
       case 'p': p.pvalue     = std::atof(ARGF()); break; // p-value
       case 'r': p.sample     = std::atoi(ARGF()); break; // bootstrap sample number
-      case 's': p.subnetfile = ARGF(); break;            // subset of probes
+      case 's': p.subnetfile = ARGF();                   // subset of probes
+                if (p.subnetfile == "")
+                   throw std::string("Option '-s' requires a subnetwork file.");
+                break;
       case 't': p.threshold  = std::atof(ARGF()); break; // mi threshold
       case 'v': p.verbose    = ARGF(); break;            // verbose
       default : throw std::string("unknown parameter ") + ARGC();
@@ -210,11 +213,6 @@ void runStandard(int argc, char *argv[])
                 << std::endl;
    }
 
-   if (p.correction != 0.0)
-      data.computeMarkerVariance(arrays);
-
-   data.computeMarkerBandwidth(arrays);
-
    std::vector<int> ids;
 
    if (p.hub != "")
@@ -232,16 +230,42 @@ void runStandard(int argc, char *argv[])
    }
 
    int numSubnets = p.subnet.size();
+   int numMissingSubnets = 0;
 
    for (int i = 0; i < numSubnets; i++)
    {
       int gid = data.getProbeId(p.subnet[i]);
       if (gid == -1)
+      {
          std::cout << "Cannot find probe: " << p.subnet[i] << " in \""
                    << p.subnetfile << "\" ... ignored." << std::endl;
+         numMissingSubnets++;
+      }
       else
          ids.push_back(gid);
    }
+
+   if (p.subnetfile != "")
+   {
+      std::cout << "[SUBNETWORK] Requested: " << numSubnets
+                << ", matched: " << ids.size()
+                << ", missing: " << numMissingSubnets << std::endl;
+
+      if (ids.size() == 0)
+      {
+         std::ostringstream s;
+         s << "Subnetwork file \"" << p.subnetfile << "\" was supplied, but zero "
+           << "probe IDs matched the first column of \"" << p.infile
+           << "\" (requested: " << numSubnets
+           << "). Refusing to construct an all-gene network.";
+         throw s.str();
+      }
+   }
+
+   if (p.correction != 0.0)
+      data.computeMarkerVariance(arrays);
+
+   data.computeMarkerBandwidth(arrays);
 
    Transfac transfac;
 

--- a/SJARACNe/src/main.cpp
+++ b/SJARACNe/src/main.cpp
@@ -201,6 +201,19 @@ void runStandard(int argc, char *argv[])
       nsample = arrays->size();
    }
 
+   if (nsample < 2)
+   {
+      std::ostringstream s;
+      s << "At least 2 observations are required for MI calculation; found "
+        << nsample;
+
+      if (arrays != NULL)
+         s << " after conditional selection";
+
+      s << ".";
+      throw s.str();
+   }
+
    std::cout << "Marker No: " << data.markerset.size()
              << " (" << data.Get_Num_Active_Markers() << " active)"
              << ", Array No: " << nsample << std::endl;

--- a/SJARACNe/src/main.cpp
+++ b/SJARACNe/src/main.cpp
@@ -284,7 +284,39 @@ void runStandard(int argc, char *argv[])
    Matrix matrix;
 
    if (p.adjfile != "")
+   {
       matrix.read(data, p);
+      std::vector<int> missingAdjacencyRows;
+
+      for (std::vector<int>::const_iterator id = ids.begin(); id != ids.end(); ++id)
+         if (!matrix.hasAdjacencyRow(*id))
+            missingAdjacencyRows.push_back(*id);
+
+      if (!missingAdjacencyRows.empty())
+      {
+         std::ostringstream s;
+         s << "Adjacency file \"" << p.adjfile
+           << "\" does not contain a source row for requested hub";
+
+         if (missingAdjacencyRows.size() > 1)
+            s << "s";
+
+         s << ": ";
+
+         for (std::vector<int>::size_type i = 0;
+              i < missingAdjacencyRows.size(); ++i)
+         {
+            if (i > 0)
+               s << ", ";
+
+            const Marker& marker = data.markerset[missingAdjacencyRows[i]];
+            s << marker.accnum.substr(1);
+         }
+
+         s << ". Refusing to treat absent adjacency rows as empty networks.";
+         throw s.str();
+      }
+   }
    else
    {
       std::vector<int> bs;

--- a/SJARACNe/src/matrix.cpp
+++ b/SJARACNe/src/matrix.cpp
@@ -5,7 +5,9 @@
 //------------------------------------------------------------------------------------
 
 #include <algorithm>
+#include <cerrno>
 #include <cctype>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
@@ -163,6 +165,9 @@ std::ostream& operator<<(std::ostream& out, const Microarray_Set& ms)
 
 void Matrix::saveNode(int i, int j, double mi)
 {
+   if (!std::isfinite(mi))
+      throw std::string("Refusing to store a non-finite MI value.");
+
    NodeMap& nmap = nmv[i];
 
    NodeMap::iterator npos = nmap.find(j);
@@ -184,6 +189,43 @@ void Matrix::read(Microarray_Set& data, const Parameter& p)
    read(in, data, p);
 
    in.close();
+}
+
+//------------------------------------------------------------------------------------
+
+static double parseMutualInformation(const std::string& text,
+                                     const std::string& source,
+                                     const std::string& target,
+                                     const std::string& filename)
+{
+   const char *begin = text.c_str();
+   char *end = NULL;
+   errno = 0;
+
+   double mi = std::strtod(begin, &end);
+   const bool converted = (end != NULL && end != begin);
+
+   while (end != NULL && *end != '\0' &&
+          std::isspace(static_cast<unsigned char>(*end)))
+      end++;
+
+   std::ostringstream s;
+
+   if (!converted || end == NULL || *end != '\0' || errno == ERANGE)
+   {
+      s << "Invalid MI value \"" << text << "\" for edge " << source
+        << " -> " << target << " in adjacency file \"" << filename << "\".";
+      throw s.str();
+   }
+
+   if (!std::isfinite(mi))
+   {
+      s << "Non-finite MI value \"" << text << "\" for edge " << source
+        << " -> " << target << " in adjacency file \"" << filename << "\".";
+      throw s.str();
+   }
+
+   return mi;
 }
 
 //------------------------------------------------------------------------------------
@@ -225,7 +267,9 @@ void Matrix::read(std::istream& in, Microarray_Set& data, const Parameter& p)
 
          std::getline(sin, value, '\t');
 
-         double mi = std::atof(value.c_str());
+         const std::string source = data.markerset[geneId1].accnum.substr(1);
+         const std::string target = label.substr(1);
+         double mi = parseMutualInformation(value, source, target, p.adjfile);
 
          if (mi >= p.threshold)
          {
@@ -635,6 +679,22 @@ int Microarray_Set::readMarkerWithPvalue(std::istream& in, const int arrno)
             default : pval = std::atof(sPVal.c_str());
          }
 
+         if (!std::isfinite(val))
+         {
+            std::ostringstream s;
+            s << "Non-finite expression value at gene row " << arrno + 1
+              << ", observation " << markern + 1 << ".";
+            throw s.str();
+         }
+
+         if (!std::isfinite(pval))
+         {
+            std::ostringstream s;
+            s << "Non-finite expression p-value at gene row " << arrno + 1
+              << ", observation " << markern + 1 << ".";
+            throw s.str();
+         }
+
          Set_Probe(markern++, arrno, Probe(val, pval));
       }
       while (in.good() && in.get() != '\015' && in.peek() != EOF &&
@@ -668,6 +728,14 @@ int Microarray_Set::readMarkerNoPvalue(std::istream& in, const int arrno)
          double val;
 
          in >> val;
+
+         if (!std::isfinite(val))
+         {
+            std::ostringstream s;
+            s << "Non-finite expression value at gene row " << arrno + 1
+              << ", observation " << markern + 1 << ".";
+            throw s.str();
+         }
 
          Set_Probe(markern++, arrno, Probe(val, 0.0));
       }
@@ -714,6 +782,19 @@ int Microarray_Set::readHeader(std::istream& in)
 
 //------------------------------------------------------------------------------------
 
+static void validateObservationCount(int expected, int actual, int lineNumber)
+{
+   if (actual != expected)
+   {
+      std::ostringstream s;
+      s << "Incorrect expression dimensions at line " << lineNumber
+        << ": expected " << expected << " observations, found " << actual << ".";
+      throw s.str();
+   }
+}
+
+//------------------------------------------------------------------------------------
+
 void Microarray_Set::read(const std::string& filename)
 {
    std::ifstream in(filename.c_str());
@@ -739,6 +820,14 @@ void Microarray_Set::read(std::istream& in)
       std::istringstream sin(line);
       int arrno = readHeader(sin);
 
+      if (arrno < 2)
+      {
+         std::ostringstream s;
+         s << "Expression matrix must contain at least 2 observation columns; found "
+           << arrno << ".";
+         throw s.str();
+      }
+
       // we need to decide whether the input file contain only expression
       // or (value, pvalue) pairs
 
@@ -753,6 +842,8 @@ void Microarray_Set::read(std::istream& in)
 
       std::cout << "\n[READ] " << bypass_line_cnt
                 << " Description lines bypassed." << std::endl;
+
+      const int firstDataLine = bypass_line_cnt + 2;
 
       std::istringstream pin(line);
       std::vector<std::string> firstprobe;
@@ -784,7 +875,9 @@ void Microarray_Set::read(std::istream& in)
 
          Marker m(proben, accnum, label);
          Set_Marker(proben, m);
-         readMarkerNoPvalue(fin, proben++);
+         int observations = readMarkerNoPvalue(fin, proben);
+         validateObservationCount(arrno, observations, firstDataLine);
+         proben++;
 
          while (in.good() && in.peek() != EOF)
          {
@@ -799,12 +892,9 @@ void Microarray_Set::read(std::istream& in)
             Marker m(proben, accnum, label);
             Set_Marker(proben, m);
 
-            if (readMarkerNoPvalue(sin, proben) != arrno)
-            {
-               std::ostringstream s;
-               s << "Incorrect data format at line no: " << proben + 2;
-               throw s.str();
-            }
+            int observations = readMarkerNoPvalue(sin, proben);
+            validateObservationCount(arrno, observations,
+                                     firstDataLine + proben);
 
             proben++;
          }
@@ -826,7 +916,9 @@ void Microarray_Set::read(std::istream& in)
 
          Marker m(proben, accnum, label);
          Set_Marker(proben, m);
-         readMarkerWithPvalue(fin, proben++);
+         int observations = readMarkerWithPvalue(fin, proben);
+         validateObservationCount(arrno, observations, firstDataLine);
+         proben++;
 
          while (in.good() && in.peek() != EOF)
          {
@@ -841,19 +933,23 @@ void Microarray_Set::read(std::istream& in)
             Marker m(proben, accnum, label);
             Set_Marker(proben, m);
 
-            if (readMarkerWithPvalue(sin, proben) != arrno)
-            {
-               std::ostringstream s;
-               s << "Incorrect data format at line no: " << proben + 2;
-               throw s.str();
-            }
+            int observations = readMarkerWithPvalue(sin, proben);
+            validateObservationCount(arrno, observations,
+                                     firstDataLine + proben);
 
             proben++;
          }
       }
       else
-         throw std::string("Incorrect file format: header line doesn't match the "
-                           "rest of the data.");
+      {
+         std::ostringstream s;
+         s << "Incorrect expression dimensions at line " << firstDataLine
+           << ": header declares " << arrno << " observations, but the first row "
+           << "contains " << valueNo << " data fields; expected " << arrno
+           << " expression values or " << 2 * arrno
+           << " expression/p-value fields.";
+         throw s.str();
+      }
    }
    catch (std::ios_base::failure& f)
    {
@@ -1219,6 +1315,16 @@ double Microarray_Set::calculateMI(int maNum, int probeId1, int probeId2,
 
    double mi = Compute_Pairwise_MI(pairs, nparLimit);
 
+   if (!std::isfinite(mi))
+   {
+      std::ostringstream s;
+      s << "Non-finite MI calculated for edge "
+        << markerset[probeId1].accnum.substr(1) << " -> "
+        << markerset[probeId2].accnum.substr(1) << " using " << maNum
+        << " observations.";
+      throw s.str();
+   }
+
    if (mi < threshold)
       return 0.0;
 
@@ -1232,7 +1338,19 @@ double Microarray_Set::calculateMI(int maNum, int probeId1, int probeId2,
 
    double value  = 1 + (std::exp(2 * mi) - 1) * (1 - 1 / lambda);
 
-   return (mi + 0.5 * std::log(value));
+   double correctedMi = mi + 0.5 * std::log(value);
+
+   if (!std::isfinite(correctedMi))
+   {
+      std::ostringstream s;
+      s << "Non-finite noise-corrected MI calculated for edge "
+        << markerset[probeId1].accnum.substr(1) << " -> "
+        << markerset[probeId2].accnum.substr(1) << " using " << maNum
+        << " observations.";
+      throw s.str();
+   }
+
+   return correctedMi;
 }
 
 //------------------------------------------------------------------------------------

--- a/SJARACNe/src/matrix.cpp
+++ b/SJARACNe/src/matrix.cpp
@@ -190,6 +190,11 @@ void Matrix::read(Microarray_Set& data, const Parameter& p)
 
 void Matrix::read(std::istream& in, Microarray_Set& data, const Parameter& p)
 {
+   // The expression matrix defines the complete gene-ID space.  Pre-sizing
+   // prevents sparse -j inputs from leaving requested rows out of bounds.
+   nmv.assign(data.markerset.size(), NodeMap());
+   adjacencyRowsPresent.assign(data.markerset.size(), false);
+
    std::string line;
 
    std::getline(in, line);
@@ -209,9 +214,7 @@ void Matrix::read(std::istream& in, Microarray_Set& data, const Parameter& p)
          throw "Cannot find marker: " + label + " in the ADJ file!";
 
       data.markerset[geneId1].isActive = true;
-
-      while (nmv.size() <= geneId1)
-         nmv.push_back(NodeMap());
+      adjacencyRowsPresent[geneId1] = true;
 
       std::getline(sin, label, '\t');
       label = "_" + label;
@@ -230,9 +233,6 @@ void Matrix::read(std::istream& in, Microarray_Set& data, const Parameter& p)
             if (geneId2 == -1)
                throw "Cannot find marker: " + label + " in the ADJ file!";
 
-            while (nmv.size() <= geneId2)
-               nmv.push_back(NodeMap());
-
             saveNode(geneId1, geneId2, mi);
          }
 
@@ -242,6 +242,15 @@ void Matrix::read(std::istream& in, Microarray_Set& data, const Parameter& p)
 
       std::getline(in, line);
    }
+}
+
+//------------------------------------------------------------------------------------
+
+bool Matrix::hasAdjacencyRow(int geneId) const
+{
+   return geneId >= 0 &&
+          static_cast<std::size_t>(geneId) < adjacencyRowsPresent.size() &&
+          adjacencyRowsPresent[geneId];
 }
 
 //------------------------------------------------------------------------------------

--- a/SJARACNe/src/matrix.h
+++ b/SJARACNe/src/matrix.h
@@ -44,9 +44,11 @@ class Matrix
 {
 public:
    Matrix()
-      : nmv(), writeTriangular(false), writeReduced(false), writeEmptyGenes(false) { }
+      : nmv(), adjacencyRowsPresent(), writeTriangular(false),
+        writeReduced(false), writeEmptyGenes(false) { }
 
    NodeMapVector nmv;
+   std::vector<bool> adjacencyRowsPresent;
 
    bool writeTriangular; // if true, only triangular half of matrix will be written
    bool writeReduced;    // if true, intermediate nodes will be written
@@ -56,6 +58,7 @@ public:
 
    void read(Microarray_Set& data, const Parameter& p);
    void read(std::istream& in, Microarray_Set& data, const Parameter& p);
+   bool hasAdjacencyRow(int geneId) const;
 
    void writeGeneLine(std::ostream& out, const Microarray_Set& data, int geneId);
    void writeGeneList(const Microarray_Set& data, const std::string& name,

--- a/SJARACNe/src/param.cpp
+++ b/SJARACNe/src/param.cpp
@@ -8,7 +8,6 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include "param.h"
 
 //------------------------------------------------------------------------------------
@@ -105,32 +104,62 @@ void checkParameter(Parameter &p)
 }
 
 //------------------------------------------------------------------------------------
-// readProbeList() reads the list of nodes to be included in constructing a subnetwork
+// appendProbeId() normalizes and stores one identifier from a hub-list record.
+
+static void appendProbeId(std::string gid, bool first_record,
+                          std::vector<std::string>& probe_list)
+{
+   const std::string utf8_bom("\xEF\xBB\xBF", 3);
+
+   if (first_record && gid.compare(0, utf8_bom.length(), utf8_bom) == 0)
+      gid.erase(0, utf8_bom.length());
+
+   const std::string whitespace(" \t\n\r\f\v");
+   std::string::size_type first = gid.find_first_not_of(whitespace);
+
+   if (first == std::string::npos)
+      return;
+
+   std::string::size_type last = gid.find_last_not_of(whitespace);
+   gid = gid.substr(first, last - first + 1);
+
+   probe_list.push_back("_" + gid);
+}
+
+//------------------------------------------------------------------------------------
+// readProbeList() reads and normalizes the list of nodes used by -s and -l.
 
 static int readProbeList(const std::string& infilename,
                          std::vector<std::string>& probe_list)
 {
-   std::ifstream in(infilename.c_str());
+   std::ifstream in(infilename.c_str(), std::ios::binary);
    if (!in.is_open())
       throw "Unable to open " + infilename;
 
    std::string line;
-   int lnum = 0;
+   bool first_record = true;
+   char c;
 
-   while (in.good() && in.peek() != EOF && in.peek() != '\012')
+   while (in.get(c))
    {
-      std::getline(in, line);
-      std::istringstream sin(line);
-      std::string gid;
-      std::getline(sin, gid);
-      gid = "_" + gid;
-      probe_list.push_back(gid);
-      lnum++;
+      if (c == '\n' || c == '\r')
+      {
+         appendProbeId(line, first_record, probe_list);
+         line.clear();
+         first_record = false;
+
+         // Consume LF as part of a CRLF delimiter. A lone CR is also a valid
+         // delimiter, which keeps classic Mac and mixed-ending files readable.
+         if (c == '\r' && in.peek() == '\n')
+            in.get(c);
+      }
+      else
+         line += c;
    }
 
-   in.close();
+   appendProbeId(line, first_record, probe_list);
 
-   return lnum;
+   return probe_list.size();
 }
 
 //------------------------------------------------------------------------------------

--- a/SJARACNe/src/param.cpp
+++ b/SJARACNe/src/param.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <set>
 #include "param.h"
 
 //------------------------------------------------------------------------------------
@@ -107,7 +108,9 @@ void checkParameter(Parameter &p)
 // appendProbeId() normalizes and stores one identifier from a hub-list record.
 
 static void appendProbeId(std::string gid, bool first_record,
-                          std::vector<std::string>& probe_list)
+                          std::vector<std::string>& probe_list,
+                          std::set<std::string>& seen,
+                          int& duplicate_count)
 {
    const std::string utf8_bom("\xEF\xBB\xBF", 3);
 
@@ -122,20 +125,29 @@ static void appendProbeId(std::string gid, bool first_record,
 
    std::string::size_type last = gid.find_last_not_of(whitespace);
    gid = gid.substr(first, last - first + 1);
+   gid = "_" + gid;
 
-   probe_list.push_back("_" + gid);
+   if (seen.insert(gid).second)
+      probe_list.push_back(gid);
+   else
+      duplicate_count++;
 }
 
 //------------------------------------------------------------------------------------
 // readProbeList() reads and normalizes the list of nodes used by -s and -l.
 
 static int readProbeList(const std::string& infilename,
-                         std::vector<std::string>& probe_list)
+                         std::vector<std::string>& probe_list,
+                         int& duplicate_count)
 {
    std::ifstream in(infilename.c_str(), std::ios::binary);
    if (!in.is_open())
       throw "Unable to open " + infilename;
 
+   probe_list.clear();
+   duplicate_count = 0;
+
+   std::set<std::string> seen;
    std::string line;
    bool first_record = true;
    char c;
@@ -144,7 +156,7 @@ static int readProbeList(const std::string& infilename,
    {
       if (c == '\n' || c == '\r')
       {
-         appendProbeId(line, first_record, probe_list);
+         appendProbeId(line, first_record, probe_list, seen, duplicate_count);
          line.clear();
          first_record = false;
 
@@ -157,7 +169,7 @@ static int readProbeList(const std::string& infilename,
          line += c;
    }
 
-   appendProbeId(line, first_record, probe_list);
+   appendProbeId(line, first_record, probe_list, seen, duplicate_count);
 
    return probe_list.size();
 }
@@ -183,8 +195,16 @@ void displayParameter(Parameter &p)
                 << p.correction << ")" << std::endl;
 
    if (p.subnetfile != "")
+   {
+      int duplicate_count = 0;
       std::cout << "[PARA] Subset of probes to reconstruct: " << p.subnetfile
-                << " (" << readProbeList(p.subnetfile, p.subnet) << ")" << std::endl;
+                << " (" << readProbeList(p.subnetfile, p.subnet, duplicate_count)
+                << ")" << std::endl;
+
+      if (duplicate_count > 0)
+         std::cout << "[PARA] Duplicate subnetwork probes ignored: "
+                   << duplicate_count << std::endl;
+   }
 
    if (p.hub != "")
       std::cout << "[PARA] Hub probe to reconstruct: " << p.hub << std::endl;
@@ -197,8 +217,16 @@ void displayParameter(Parameter &p)
    }
 
    if (p.annotfile != "")
+   {
+      int duplicate_count = 0;
       std::cout << "[PARA] TF annotation list: " << p.annotfile
-                << " (" << readProbeList(p.annotfile, p.tf_list) << ")" << std::endl;
+                << " (" << readProbeList(p.annotfile, p.tf_list, duplicate_count)
+                << ")" << std::endl;
+
+      if (duplicate_count > 0)
+         std::cout << "[PARA] Duplicate TF annotation probes ignored: "
+                   << duplicate_count << std::endl;
+   }
 
    if (p.mean != 0.0 || p.cv != 0.0)
    {

--- a/tests/test_create_consensus_network.py
+++ b/tests/test_create_consensus_network.py
@@ -163,5 +163,75 @@ class TestConsensusDuplicateEdges(unittest.TestCase):
         self.assertIn("A\tB\t0.5000\n", network)
         self.assertIn("B\tA\t0.7000\n", network)
 
+
+class TestEmptyConsensusNetwork(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+        self.adjacency_dir = self.workdir / "bootstraps"
+        self.output_dir = self.workdir / "output"
+        self.expression = self.workdir / "small.exp"
+        self.expression.write_text(
+            "isoformId\tgeneSymbol\ts1\ts2\ts3\n"
+            "A\tA\t1\t2\t3\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    def write_empty_bootstrap(self, filename):
+        self.adjacency_dir.mkdir(parents=True, exist_ok=True)
+        (self.adjacency_dir / filename).write_text(
+            ">  Input file test.exp\n>  Subnetwork file hubs.txt\n",
+            encoding="utf-8",
+        )
+
+    def test_empty_bootstrap_networks_produce_headers_and_metadata(self):
+        self.write_empty_bootstrap("run_1.adj")
+        self.write_empty_bootstrap("run_2.adj")
+
+        network = cn(self.adjacency_dir, 0.05, self.output_dir)
+        ecn(self.expression, network, self.output_dir)
+
+        self.assertEqual(
+            (self.output_dir / "consensus_network_3col_.txt").read_text(
+                encoding="utf-8"
+            ),
+            "source\ttarget\tMI\n",
+        )
+        self.assertEqual(
+            (self.output_dir / "consensus_network_ncol_.txt").read_text(
+                encoding="utf-8"
+            ),
+            "source\ttarget\tsource.symbol\ttarget.symbol\tMI\tpearson\t"
+            "spearman\tslope\tp-value\n",
+        )
+        self.assertEqual(
+            (self.output_dir / "bootstrap_info_.txt").read_text(encoding="utf-8"),
+            "Total edge tested: 0\n"
+            "Bonferroni corrected (0.05) alpha: N/A (no edges tested)\n"
+            "mu: 0.0\n"
+            "sigma: 0.0\n",
+        )
+
+        parameter_info = (self.output_dir / "parameter_info_.txt").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(">  Input file test.exp\n", parameter_info)
+        self.assertIn(">  Subnetwork file hubs.txt\n", parameter_info)
+        self.assertIn(">  Bootstrap No: 2\n", parameter_info)
+        self.assertIn(">  Source: sjaracne2\n", parameter_info)
+
+    def test_missing_bootstrap_files_fail_clearly(self):
+        self.adjacency_dir.mkdir()
+
+        with self.assertRaisesRegex(ValueError, "No bootstrap adjacency files found"):
+            cn(self.adjacency_dir, 0.05, self.output_dir)
+
+        self.assertFalse(
+            (self.output_dir / "consensus_network_3col_.txt").exists()
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_create_consensus_network.py
+++ b/tests/test_create_consensus_network.py
@@ -4,6 +4,7 @@ import unittest
 import filecmp
 import tempfile
 import sys
+from pathlib import Path
 from SJARACNe.bin.create_consensus_network import create_consensus_network as cn
 from SJARACNe.bin.create_consensus_network import create_enhanced_consensus_network as ecn
 from SJARACNe.bin.create_consensus_network import uprob
@@ -50,6 +51,117 @@ class TestConsensusNetwork(unittest.TestCase):
 
     def test_uprob_neg1(self):
         self.assertAlmostEqual(0.841344680778, uprob(-1))
+
+
+class TestConsensusDuplicateEdges(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    @staticmethod
+    def write_bootstrap(directory, filename, body):
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / filename).write_text(
+            ">  Input file test.exp\n" + body,
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def read_network(output_dir):
+        return (output_dir / "consensus_network_3col_.txt").read_text(
+            encoding="utf-8"
+        )
+
+    def test_duplicate_edge_occurrences_count_once_per_bootstrap(self):
+        clean_dir = self.workdir / "clean"
+        duplicate_dir = self.workdir / "duplicate"
+        clean_output = self.workdir / "clean_output"
+        duplicate_output = self.workdir / "duplicate_output"
+
+        self.write_bootstrap(clean_dir, "run_1.adj", "A\tB\t0.5\tC\t0.2\n")
+        self.write_bootstrap(clean_dir, "run_2.adj", "A\tB\t0.7\n")
+        self.write_bootstrap(
+            duplicate_dir,
+            "run_1.adj",
+            "A\tB\t0.5\tB\t0.5\tC\t0.2\nA\tB\t0.5\n",
+        )
+        self.write_bootstrap(duplicate_dir, "run_2.adj", "A\tB\t0.7\n")
+
+        cn(clean_dir, 1.0, clean_output)
+        with self.assertLogs(level="WARNING") as logs:
+            cn(duplicate_dir, 1.0, duplicate_output)
+
+        self.assertIn("Ignored 2 duplicate edge occurrence(s)", "\n".join(logs.output))
+        self.assertEqual(
+            self.read_network(duplicate_output), self.read_network(clean_output)
+        )
+        self.assertIn("A\tB\t0.6000\n", self.read_network(duplicate_output))
+        self.assertEqual(
+            (duplicate_output / "bootstrap_info_.txt").read_text(encoding="utf-8"),
+            (clean_output / "bootstrap_info_.txt").read_text(encoding="utf-8"),
+        )
+
+    def test_conflicting_duplicate_mi_values_fail_closed(self):
+        adjacency_dir = self.workdir / "conflicting"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(
+            adjacency_dir,
+            "run_1.adj",
+            "A\tB\t0.5\nA\tB\t0.6\n",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Conflicting MI values for duplicate edge A----B.*0.5 versus 0.6",
+        ):
+            cn(adjacency_dir, 1.0, output_dir)
+
+        self.assertFalse((output_dir / "consensus_network_3col_.txt").exists())
+
+    def test_equivalent_mi_text_is_an_exact_numeric_duplicate(self):
+        adjacency_dir = self.workdir / "equivalent"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(
+            adjacency_dir,
+            "run_1.adj",
+            "A\tB\t0.5\nA\tB\t0.5000\n",
+        )
+
+        with self.assertLogs(level="WARNING"):
+            cn(adjacency_dir, 1.0, output_dir)
+
+        self.assertIn("A\tB\t0.5000\n", self.read_network(output_dir))
+
+    def test_nonfinite_mi_fails_closed(self):
+        adjacency_dir = self.workdir / "nonfinite"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(adjacency_dir, "run_1.adj", "A\tB\tnan\n")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Non-finite MI value for edge A----B.*nan",
+        ):
+            cn(adjacency_dir, 1.0, output_dir)
+
+        self.assertFalse((output_dir / "consensus_network_3col_.txt").exists())
+
+    def test_reverse_ordered_edge_is_not_treated_as_a_duplicate(self):
+        adjacency_dir = self.workdir / "directed"
+        output_dir = self.workdir / "output"
+        self.write_bootstrap(
+            adjacency_dir,
+            "run_1.adj",
+            "A\tB\t0.5\nB\tA\t0.7\n",
+        )
+
+        cn(adjacency_dir, 1.0, output_dir)
+
+        network = self.read_network(output_dir)
+        self.assertIn("A\tB\t0.5000\n", network)
+        self.assertIn("B\tA\t0.7000\n", network)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_qc_input.py
+++ b/tests/test_qc_input.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+QC_SCRIPT = PROJECT_ROOT / "SJARACNe" / "bin" / "QC_input.py"
+
+
+class TestQCInput(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+        self.expression = self.workdir / "small.exp"
+        self.expression.write_text(
+            "isoformId\tgeneSymbol\ts1\ts2\n"
+            "A\tA\t1\t2\n"
+            "B\tB\t2\t1\n"
+            "C\tC\t3\t4\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    def run_qc(self, probe_file):
+        report = self.workdir / "hub_overlap_validation.txt"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(QC_SCRIPT),
+                "-e",
+                str(self.expression),
+                "-g",
+                str(probe_file),
+                "-o",
+                str(report),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result, report
+
+    @staticmethod
+    def read_report(report):
+        return dict(
+            line.split("\t", 1)
+            for line in report.read_text(encoding="utf-8").splitlines()
+        )
+
+    def test_partial_overlap_passes_and_reports_normalized_unique_hubs(self):
+        probes = self.workdir / "partial_hubs.txt"
+        probes.write_bytes(b"\xef\xbb\xbf A \r\n\r\n\tA\t\rMISSING\n")
+
+        result, report = self.run_qc(probes)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(report.is_file())
+        self.assertIn("Hub overlap: requested=2, matched=1, missing=1", result.stderr)
+        self.assertEqual(
+            self.read_report(report),
+            {
+                "status": "passed",
+                "expression_genes": "3",
+                "hub_genes_requested": "2",
+                "hub_genes_matched": "1",
+                "hub_genes_missing": "1",
+                "hub_duplicates_ignored": "1",
+                "matched_hubs": "A",
+                "missing_hubs": "MISSING",
+            },
+        )
+
+    def test_zero_overlap_fails_before_creating_validation_report(self):
+        probes = self.workdir / "unresolved_hubs.txt"
+        probes.write_text("NOT_PRESENT\nNOT_PRESENT\n", encoding="utf-8")
+
+        result, report = self.run_qc(probes)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requested=1, matched=0, missing=1", result.stderr)
+        self.assertIn("Refusing to start bootstrap jobs", result.stderr)
+        self.assertFalse(report.exists())
+
+    def test_blank_hub_file_fails_before_creating_validation_report(self):
+        probes = self.workdir / "blank_hubs.txt"
+        probes.write_text(" \n\t\r\n", encoding="utf-8")
+
+        result, report = self.run_qc(probes)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requested=0, matched=0, missing=0", result.stderr)
+        self.assertIn("Refusing to start bootstrap jobs", result.stderr)
+        self.assertFalse(report.exists())
+
+    def test_bootstrap_has_hard_dependency_on_validation_report(self):
+        workflow = (
+            PROJECT_ROOT / "SJARACNe" / "cwl" / "sjaracne_workflow.cwl"
+        ).read_text(encoding="utf-8")
+        qc_tool = (PROJECT_ROOT / "SJARACNe" / "cwl" / "QC_input.cwl").read_text(
+            encoding="utf-8"
+        )
+        bootstrap_tool = (
+            PROJECT_ROOT / "SJARACNe" / "cwl" / "sjaracne.cwl"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("out: [validation_report]", workflow)
+        self.assertIn(
+            "preflight_report: validate_files/validation_report", workflow
+        )
+        self.assertIn(
+            "validation_report:\n    type: File\n    outputBinding:", qc_tool
+        )
+        self.assertIn(
+            "preflight_report:\n    type: File?\n    doc:", bootstrap_tool
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qc_input.py
+++ b/tests/test_qc_input.py
@@ -120,6 +120,25 @@ class TestQCInput(unittest.TestCase):
             "preflight_report:\n    type: File?\n    doc:", bootstrap_tool
         )
 
+    def test_active_python_cwl_tools_do_not_depend_on_script_shebangs(self):
+        cwl_dir = PROJECT_ROOT / "SJARACNe" / "cwl"
+        expected_commands = {
+            "QC_input.cwl": "baseCommand: [python3, -m, SJARACNe.bin.QC_input]",
+            "ch_line_ending.cwl": (
+                "baseCommand: [python3, -m, SJARACNe.bin.ch_line_ending]"
+            ),
+            "create_consensus_network.cwl": (
+                "baseCommand: [python3, -m, SJARACNe.bin.create_consensus_network]"
+            ),
+        }
+
+        for filename, expected in expected_commands.items():
+            with self.subTest(filename=filename):
+                self.assertIn(
+                    expected,
+                    (cwl_dir / filename).read_text(encoding="utf-8"),
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sjaracne_adjacency_input.py
+++ b/tests/test_sjaracne_adjacency_input.py
@@ -112,6 +112,20 @@ class TestAdjacencyInput(unittest.TestCase):
         self.assertTrue(output.is_file())
         self.assertEqual(self.data_rows(output), ["A\tB\t0.5"])
 
+    def test_three_gene_dpi_triangle_prunes_the_weakest_edge(self):
+        result, output = self.run_sjaracne(
+            "A\tB\t0.2\tC\t0.8\n"
+            "B\tC\t0.7\n"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("[NETWORK] Applying DPI", result.stdout)
+        self.assertTrue(output.is_file())
+        self.assertEqual(
+            self.data_rows(output),
+            ["A\tC\t0.8", "B\tC\t0.7"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sjaracne_adjacency_input.py
+++ b/tests/test_sjaracne_adjacency_input.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def find_sjaracne_executable():
+    configured = os.environ.get("SJARACNE_TEST_EXE")
+    candidates = [
+        configured,
+        Path(__file__).resolve().parents[1] / "SJARACNe" / "bin" / "sjaracne.exe",
+        shutil.which("sjaracne.exe"),
+    ]
+
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return str(candidate)
+    return None
+
+
+SJARACNE_EXE = find_sjaracne_executable()
+
+
+@unittest.skipUnless(SJARACNE_EXE, "sjaracne.exe is not built")
+class TestAdjacencyInput(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+        self.expression = self.workdir / "small.exp"
+        self.expression.write_text(
+            "isoformId\tgeneSymbol\ts1\ts2\ts3\ts4\ts5\ts6\n"
+            "A\tA\t1\t2\t3\t4\t5\t6\n"
+            "B\tB\t6\t5\t4\t3\t2\t1\n"
+            "C\tC\t1\t3\t2\t6\t4\t5\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    def run_sjaracne(self, adjacency_body, hubs=None):
+        adjacency = self.workdir / "input.adj"
+        adjacency.write_text(adjacency_body, encoding="utf-8")
+        output = self.workdir / "output.adj"
+        command = [
+            SJARACNE_EXE,
+            "-i",
+            str(self.expression),
+            "-j",
+            str(adjacency),
+            "-p",
+            "1",
+            "-e",
+            "0",
+            "-o",
+            str(output),
+        ]
+
+        if hubs is not None:
+            hub_file = self.workdir / "hubs.txt"
+            hub_file.write_text(hubs, encoding="utf-8")
+            command.extend(["-s", str(hub_file)])
+
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+        return result, output
+
+    @staticmethod
+    def data_rows(output):
+        return [
+            line
+            for line in output.read_text(encoding="utf-8").splitlines()
+            if line and not line.startswith(">")
+        ]
+
+    def test_requested_hub_missing_as_source_row_fails_cleanly(self):
+        result, output = self.run_sjaracne("A\tB\t0.5\n", hubs="C\n")
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn(
+            "does not contain a source row for requested hub: C", result.stderr
+        )
+        self.assertIn(
+            "Refusing to treat absent adjacency rows as empty networks",
+            result.stderr,
+        )
+        self.assertFalse(output.exists())
+
+    def test_requested_hub_appearing_only_as_target_is_still_absent(self):
+        result, output = self.run_sjaracne("A\tC\t0.5\n", hubs="C\n")
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn(
+            "does not contain a source row for requested hub: C", result.stderr
+        )
+        self.assertFalse(output.exists())
+
+    def test_explicit_source_only_row_is_a_valid_empty_row(self):
+        result, output = self.run_sjaracne("A\tB\t0.5\nC\n", hubs="C\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(output.is_file())
+        self.assertEqual(self.data_rows(output), [])
+
+    def test_sparse_adjacency_is_safe_in_all_gene_mode(self):
+        result, output = self.run_sjaracne("A\tB\t0.5\n")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(output.is_file())
+        self.assertEqual(self.data_rows(output), ["A\tB\t0.5"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sjaracne_expression_validation.py
+++ b/tests/test_sjaracne_expression_validation.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def find_sjaracne_executable():
+    configured = os.environ.get("SJARACNE_TEST_EXE")
+    candidates = [
+        configured,
+        Path(__file__).resolve().parents[1] / "SJARACNe" / "bin" / "sjaracne.exe",
+        shutil.which("sjaracne.exe"),
+    ]
+
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return str(candidate)
+    return None
+
+
+SJARACNE_EXE = find_sjaracne_executable()
+
+
+@unittest.skipUnless(SJARACNE_EXE, "sjaracne.exe is not built")
+class TestExpressionAndMIValidation(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+        self.expression = self.workdir / "input.exp"
+        self.adjacency = self.workdir / "input.adj"
+        self.output = self.workdir / "network.adj"
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    def run_sjaracne(self, expression_body, *extra_args):
+        self.expression.write_text(expression_body, encoding="utf-8")
+        if self.output.exists():
+            self.output.unlink()
+
+        result = subprocess.run(
+            [
+                SJARACNE_EXE,
+                "-i",
+                str(self.expression),
+                "-p",
+                "1",
+                "-e",
+                "1",
+                "-o",
+                str(self.output),
+                *extra_args,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result
+
+    def test_first_expression_row_observation_count_is_validated(self):
+        cases = {
+            "expression_only": (
+                "isoformId\tgeneSymbol\ts1\ts2\n"
+                "A\tA\t1 2\t3\n"
+                "B\tB\t4\t5\n"
+            ),
+            "expression_pvalue_pairs": (
+                "isoformId\tgeneSymbol\ts1\ts2\n"
+                "A\tA\t1 0.1 2\t0.2\t3\t0.3\n"
+                "B\tB\t4\t0.1\t5\t0.2\n"
+            ),
+        }
+
+        for name, expression_body in cases.items():
+            with self.subTest(format=name):
+                result = self.run_sjaracne(expression_body)
+
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn(
+                    "Incorrect expression dimensions at line 2: "
+                    "expected 2 observations, found 3",
+                    result.stderr,
+                )
+                self.assertFalse(self.output.exists())
+
+    def test_at_least_two_observations_are_required(self):
+        result = self.run_sjaracne(
+            "isoformId\tgeneSymbol\ts1\n"
+            "A\tA\t1\n"
+            "B\tB\t2\n"
+        )
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn(
+            "must contain at least 2 observation columns; found 1",
+            result.stderr,
+        )
+        self.assertFalse(self.output.exists())
+
+    def test_conditional_selection_must_retain_two_observations(self):
+        result = self.run_sjaracne(
+            "isoformId\tgeneSymbol\ts1\ts2\ts3\ts4\ts5\ts6\n"
+            "A\tA\t1\t2\t3\t4\t5\t6\n"
+            "B\tB\t6\t5\t4\t3\t2\t1\n",
+            "-c",
+            "+_A",
+            "0.2",
+        )
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn(
+            "At least 2 observations are required for MI calculation; "
+            "found 1 after conditional selection",
+            result.stderr,
+        )
+        self.assertFalse(self.output.exists())
+
+    def test_adjacency_input_rejects_nonfinite_mi(self):
+        expression_body = (
+            "isoformId\tgeneSymbol\ts1\ts2\ts3\n"
+            "A\tA\t1\t2\t3\n"
+            "B\tB\t3\t2\t1\n"
+        )
+
+        for value in ("nan", "inf", "-inf"):
+            with self.subTest(value=value):
+                self.adjacency.write_text(
+                    "A\tB\t{}\n".format(value), encoding="utf-8"
+                )
+                result = self.run_sjaracne(
+                    expression_body, "-j", str(self.adjacency)
+                )
+
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("Non-finite MI value", result.stderr)
+                self.assertIn("A -> B", result.stderr)
+                self.assertFalse(self.output.exists())
+
+    def test_adjacency_input_rejects_malformed_mi(self):
+        expression_body = (
+            "isoformId\tgeneSymbol\ts1\ts2\ts3\n"
+            "A\tA\t1\t2\t3\n"
+            "B\tB\t3\t2\t1\n"
+        )
+
+        for value in ("not-a-number", "   "):
+            with self.subTest(value=repr(value)):
+                self.adjacency.write_text(
+                    "A\tB\t{}\n".format(value), encoding="utf-8"
+                )
+                result = self.run_sjaracne(
+                    expression_body, "-j", str(self.adjacency)
+                )
+
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertIn("Invalid MI value", result.stderr)
+                self.assertIn("A -> B", result.stderr)
+                self.assertFalse(self.output.exists())
+
+    def test_nonfinite_noise_corrected_mi_is_rejected(self):
+        result = self.run_sjaracne(
+            "isoformId\tgeneSymbol\ts1\ts2\n"
+            "A\tA\t0\t2\n"
+            "B\tB\t0\t2\n",
+            "-n",
+            "10",
+        )
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("Non-finite noise-corrected MI calculated", result.stderr)
+        self.assertIn("A -> B", result.stderr)
+        self.assertFalse(self.output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sjaracne_subnetwork_resolution.py
+++ b/tests/test_sjaracne_subnetwork_resolution.py
@@ -108,6 +108,43 @@ class TestSubnetworkResolution(unittest.TestCase):
         self.assertNotIn("Cannot find probe", result.stdout)
         self.assertTrue(output.is_file())
 
+    def test_duplicate_subnetwork_hubs_are_computed_and_written_once(self):
+        hubs = self.workdir / "duplicate_hubs.txt"
+        hubs.write_bytes(b"A\n A \r\n\tA\t\r")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"Subset of probes to reconstruct: {hubs} (1)", result.stdout)
+        self.assertIn("Duplicate subnetwork probes ignored: 2", result.stdout)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 1, matched: 1, missing: 0", result.stdout
+        )
+        self.assertIn("Gene: 1", result.stdout)
+
+        source_rows = [
+            line
+            for line in output.read_text(encoding="utf-8").splitlines()
+            if line.split("\t", 1)[0] == "A"
+        ]
+        self.assertEqual(len(source_rows), 1)
+
+    def test_duplicate_tf_annotation_hubs_are_deduplicated(self):
+        subnet = self.workdir / "single_hub.txt"
+        subnet.write_text("A\n", encoding="utf-8")
+        tf_hubs = self.workdir / "duplicate_tf_hubs.txt"
+        tf_hubs.write_bytes(b"A\r\n A \nB\r\n\tB\t\r")
+
+        result, output = self.run_sjaracne(
+            "-s", str(subnet), "-l", str(tf_hubs)
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"[PARA] TF annotation list: {tf_hubs} (2)", result.stdout)
+        self.assertIn("Duplicate TF annotation probes ignored: 2", result.stdout)
+        self.assertNotIn("Cannot find probe", result.stdout)
+        self.assertTrue(output.is_file())
+
     def test_unresolved_subnetwork_fails_instead_of_running_all_genes(self):
         hubs = self.workdir / "missing_hubs.txt"
         hubs.write_text("NOT_IN_EXPRESSION\n", encoding="utf-8")

--- a/tests/test_sjaracne_subnetwork_resolution.py
+++ b/tests/test_sjaracne_subnetwork_resolution.py
@@ -108,8 +108,20 @@ class TestSubnetworkResolution(unittest.TestCase):
         self.assertNotIn("Cannot find probe", result.stdout)
         self.assertTrue(output.is_file())
 
-    def test_duplicate_subnetwork_hubs_are_computed_and_written_once(self):
-        hubs = self.workdir / "duplicate_hubs.txt"
+    def test_duplicate_subnetwork_hub_matches_single_hub_output(self):
+        hubs = self.workdir / "equivalent_hubs.txt"
+        hubs.write_text("A\n", encoding="utf-8")
+
+        single_result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertEqual(
+            single_result.returncode,
+            0,
+            single_result.stdout + single_result.stderr,
+        )
+        self.assertTrue(output.is_file())
+        single_hub_output = output.read_bytes()
+
         hubs.write_bytes(b"A\n A \r\n\tA\t\r")
 
         result, output = self.run_sjaracne("-s", str(hubs))
@@ -121,6 +133,7 @@ class TestSubnetworkResolution(unittest.TestCase):
             "[SUBNETWORK] Requested: 1, matched: 1, missing: 0", result.stdout
         )
         self.assertIn("Gene: 1", result.stdout)
+        self.assertEqual(output.read_bytes(), single_hub_output)
 
         source_rows = [
             line

--- a/tests/test_sjaracne_subnetwork_resolution.py
+++ b/tests/test_sjaracne_subnetwork_resolution.py
@@ -80,6 +80,34 @@ class TestSubnetworkResolution(unittest.TestCase):
         self.assertIn("Gene: 1", result.stdout)
         self.assertTrue(output.is_file())
 
+    def test_subnetwork_list_normalizes_bom_whitespace_blank_lines_and_endings(self):
+        hubs = self.workdir / "normalized_hubs.txt"
+        hubs.write_bytes(b"\xef\xbb\xbf  A  \r\n\r\n\tB\t\r C \n")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 3, matched: 3, missing: 0", result.stdout
+        )
+        self.assertIn("Gene: 3", result.stdout)
+        self.assertNotIn("Cannot find probe", result.stdout)
+        self.assertTrue(output.is_file())
+
+    def test_tf_annotation_list_uses_the_same_normalization(self):
+        hubs = self.workdir / "normalized_tf_hubs.txt"
+        hubs.write_bytes(b"\xef\xbb\xbf\tA \r\n\r\n B\t\r")
+
+        result, output = self.run_sjaracne("-s", str(hubs), "-l", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(f"[PARA] TF annotation list: {hubs} (2)", result.stdout)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 2, matched: 2, missing: 0", result.stdout
+        )
+        self.assertNotIn("Cannot find probe", result.stdout)
+        self.assertTrue(output.is_file())
+
     def test_unresolved_subnetwork_fails_instead_of_running_all_genes(self):
         hubs = self.workdir / "missing_hubs.txt"
         hubs.write_text("NOT_IN_EXPRESSION\n", encoding="utf-8")

--- a/tests/test_sjaracne_subnetwork_resolution.py
+++ b/tests/test_sjaracne_subnetwork_resolution.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def find_sjaracne_executable():
+    configured = os.environ.get("SJARACNE_TEST_EXE")
+    candidates = [
+        configured,
+        Path(__file__).resolve().parents[1] / "SJARACNe" / "bin" / "sjaracne.exe",
+        shutil.which("sjaracne.exe"),
+    ]
+
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return str(candidate)
+    return None
+
+
+SJARACNE_EXE = find_sjaracne_executable()
+
+
+@unittest.skipUnless(SJARACNE_EXE, "sjaracne.exe is not built")
+class TestSubnetworkResolution(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.folder.name)
+        self.expression = self.workdir / "small.exp"
+        self.expression.write_text(
+            "isoformId\tgeneSymbol\ts1\ts2\ts3\ts4\ts5\ts6\n"
+            "A\tA\t1\t2\t3\t4\t5\t6\n"
+            "B\tB\t6\t5\t4\t3\t2\t1\n"
+            "C\tC\t1\t3\t2\t6\t4\t5\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.folder.cleanup()
+
+    def run_sjaracne(self, *extra_args):
+        output = self.workdir / "network.adj"
+        command = [
+            SJARACNE_EXE,
+            "-i",
+            str(self.expression),
+            "-p",
+            "1",
+            "-e",
+            "1",
+            "-o",
+            str(output),
+            *extra_args,
+        ]
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+        return result, output
+
+    def test_omitted_subnetwork_retains_all_gene_mode(self):
+        result, output = self.run_sjaracne()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Gene: 3", result.stdout)
+        self.assertNotIn("[SUBNETWORK]", result.stdout)
+        self.assertTrue(output.is_file())
+
+    def test_partial_subnetwork_match_continues_with_summary(self):
+        hubs = self.workdir / "partial_hubs.txt"
+        hubs.write_text("A\nNOT_IN_EXPRESSION\n", encoding="utf-8")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "[SUBNETWORK] Requested: 2, matched: 1, missing: 1", result.stdout
+        )
+        self.assertIn("Gene: 1", result.stdout)
+        self.assertTrue(output.is_file())
+
+    def test_unresolved_subnetwork_fails_instead_of_running_all_genes(self):
+        hubs = self.workdir / "missing_hubs.txt"
+        hubs.write_text("NOT_IN_EXPRESSION\n", encoding="utf-8")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("zero probe IDs matched", result.stderr)
+        self.assertIn("(requested: 1)", result.stderr)
+        self.assertIn("Refusing to construct an all-gene network", result.stderr)
+        self.assertNotIn("Gene: 3", result.stdout)
+        self.assertFalse(output.exists())
+
+    def test_empty_subnetwork_file_fails_instead_of_running_all_genes(self):
+        hubs = self.workdir / "empty_hubs.txt"
+        hubs.write_text("", encoding="utf-8")
+
+        result, output = self.run_sjaracne("-s", str(hubs))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("zero probe IDs matched", result.stderr)
+        self.assertIn("(requested: 0)", result.stderr)
+        self.assertNotIn("Gene: 3", result.stdout)
+        self.assertFalse(output.exists())
+
+    def test_subnetwork_option_without_file_is_rejected(self):
+        result, output = self.run_sjaracne("-s")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Option '-s' requires a subnetwork file", result.stderr)
+        self.assertNotIn("Gene: 3", result.stdout)
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stack and review scope

This PR is stacked on #60 (`fix/p0-network-correctness`). Until #60 is merged, GitHub will also show the Priority-0 commits in this PR. The new Priority-1 work starts at commit `1ba3164` and ends at `20e14ed`.

## What changed

### 1. Make `-j` adjacency input safe

- Pre-size adjacency storage to the full expression-gene space, so sparse adjacency files cannot leave valid gene IDs out of bounds.
- Track whether each gene was explicitly present as a source row, independently of whether that row has retained edges.
- If `-s` or `-h` requests a hub that is missing as a source row, exit with a clear error before DPI or output.
- Treat a hub appearing only as a target as missing; do not silently reinterpret it as an empty source network.
- Preserve intentional behavior for sparse all-gene `-j` input and for explicit source-only rows.

### 2. Handle valid empty consensus networks

- Treat one or more completed bootstrap files with zero edges as a valid empty result.
- Produce header-only `consensus_network_3col_.txt` and `consensus_network_ncol_.txt` files.
- Still write `bootstrap_info_.txt` and `parameter_info_.txt`; report zero tested edges, `mu = 0`, `sigma = 0`, and Bonferroni alpha as `N/A (no edges tested)`.
- Distinguish a valid zero-edge result from a directory containing no bootstrap files; the latter now fails clearly as missing input.

### 3. Reject invalid expression dimensions and MI values

- Validate the parsed observation count for the first expression row, matching the checks already applied to later rows and covering both supported expression formats.
- Require at least two observation columns because variance calculation divides by `n - 1`.
- Revalidate the effective observation count after conditional selection.
- Reject non-finite expression values and expression p-values.
- Strictly parse `-j` MI fields and reject malformed, whitespace-only, `NaN`, or infinite values before thresholding.
- Reject non-finite raw MI, noise-corrected MI, and any non-finite value reaching adjacency storage.

### 4. Focused regression coverage

Coverage now explicitly verifies:

- CRLF and mixed-ending hub lists resolve correctly.
- A completely unresolved hub list exits instead of falling back to an all-gene network.
- A duplicate hub list produces exactly the same network file as a single-hub list.
- Empty bootstrap networks complete with header-only networks and metadata.
- A requested hub absent from `-j` input exits cleanly under the agreed fail-closed behavior.
- A three-gene DPI triangle removes only the weakest edge.

## Validation

- **ASan/UBSan build:** 20 focused native tests passed.
- **Optimized build:** 32 focused Priority-0/Priority-1 tests passed.
- **Pure Python checks:** 19 tests and 3 subtests passed.
- The optimized `SJARACNe/bin/sjaracne.exe` was restored after sanitizer testing.

## Commits

- `1ba3164` - make adjacency input safe for missing rows
- `a5cb68c` - handle empty consensus networks
- `944c78e` - validate expression dimensions and MI values
- `20e14ed` - cover duplicate-hub equivalence and the DPI triangle